### PR TITLE
Update Copilot Studio plugin README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
-# Project
+# Copilot Studio Plugin
 
-> This repo has been populated by an initial template to help get you started. Please
-> make sure to update the content to build a great experience for community-building.
+This repository will be the successor to [skills-for-copilot-studio](https://github.com/microsoft/skills-for-copilot-studio). It contains an experimental plugin for creating, editing, validating, and migrating Copilot Studio YAML projects.
 
-As the maintainer of this project, please make a few updates:
+At the moment, this plugin uses an internal-only pre-release of the Power Platform CLI (`pac`). That pre-release CLI is required to use the plugin.
 
-- Improving this README.MD file to provide a great experience
-- Updating SUPPORT.MD with content about this project's support experience
-- Understanding the security reporting process in SECURITY.MD
-- Remove this section from the README
+## Disclaimer
+
+This plugin is an experimental research project, not an officially supported Microsoft product. The Copilot Studio YAML schema may change without notice. Always review and validate generated YAML before pushing to your environment - AI-generated output may contain errors or unsupported patterns. This plugin is not meant for production use.
+
+## Installation
+
+```bash
+git clone https://github.com/microsoft/skills-for-copilot-studio.git
+
+# Load for a single session
+claude --plugin-dir /path/to/skills-for-copilot-studio
+```
 
 ## Contributing
 

--- a/agents/copilot-studio-architect.md
+++ b/agents/copilot-studio-architect.md
@@ -1,5 +1,5 @@
 ---
-name: Copilot Studio Dracarys Architect
+name: Copilot Studio Architect
 description: >
   This agent accepts a detailed behavior description plus an initialized Copilot Studio CLI target project, reasons about the right agentic-loop architecture, and writes the modern YAML files that implement it. It can also migrate agents from the previous architecture to the new agentic loop.
 ---

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -71,7 +71,7 @@ Step 3: Run the migration script. Execute the migration script: node scripts\con
 The script will convert all connector and MCP servers, but will automatically skip any workflows, AI Prompts, or other unsupported actions. If the script encounters unsupported actions, do not worry. Capture the converted-tool summary and the skipped unsupported action list, then pass both to the Architect agent in the subsequent step so that the behavior can be manually refactored into instructions, skills, knowledge, or explicit open gaps.
 
 ### 7. Implement the migrated agent YAML
-After the describer produces its report and tool/action migration is complete, give the agent description as input specs for the **Copilot Studio Dracarys Architect** sub-agent (you MUST use the best of the bests AI model, high reasoning effort), and ask it to modify the newly initialized modern agent project directly.
+After the describer produces its report and tool/action migration is complete, give the agent description as input specs for the **Copilot Studio Architect** sub-agent (you MUST use the best of the bests AI model, high reasoning effort), and ask it to modify the newly initialized modern agent project directly.
 
 The architect sub-agent must receive:
 


### PR DESCRIPTION
## Summary
- Update the README with successor, pac prerequisite, disclaimer, and installation guidance
- Remove Dracarys references from Copilot Studio agent docs

## Notes
- Leaves the existing target repository unchanged after GitHub push protection blocked the clean import path