### PR TITLE
Add migration-plan approval gate to /migrate workflow

### DIFF
--- a/agents/copilot-studio-describer.md
+++ b/agents/copilot-studio-describer.md
@@ -10,7 +10,7 @@ Your only responsibility is to understand what an existing agent does and produc
 
 ## Critical final-answer rule
 
-Your final answer must be the descriptive report. It must use the exact Markdown section headings listed in `Final report`. Do not number the headings. Do not substitute headings such as "Overview", "Top-level Configuration", "Runtime Settings", "Settings / Capabilities", "Tools, Connections, Knowledge", "Behavioral Summary", or "Notable Observations". The `Active settings and capability evidence` section is mandatory. The `User stories` section is mandatory, even if it only says no meaningful functional user stories were found beyond the basic interaction.
+Your final answer must be the descriptive report. It must use the exact Markdown section headings listed in `Final report`. Do not number the headings. Do not substitute headings such as "Overview", "Top-level Configuration", "Runtime Settings", "Settings / Capabilities", "Tools, Connections, Knowledge", "Behavioral Summary", or "Notable Observations". The `Plain-language summary`, `Active settings and capability evidence`, and `Open questions and uncertainties` sections are mandatory. The `User stories` section is mandatory, even if it only says no meaningful functional user stories were found beyond the basic interaction. The report is shown to the user for explicit approval before any migration proceeds, so the `Plain-language summary` must be readable by a non-technical stakeholder and any open gaps must be stated clearly rather than buried.
 
 ## Scope boundaries
 
@@ -58,6 +58,7 @@ These are just examples. The reality is that for simple agents it will be straig
 
 Always finish with a detailed report using these exact Markdown section headings. Do not rename, omit, reorder, or replace them with alternate headings such as "Agent Identity", "Knowledge Bases", "Tools / Connectors", or "Notable Observations". These reports should go into stdout and not in a markdown file or similar.
 
+## Plain-language summary
 ## Executive summary
 ## Files and components reviewed
 ## Agent instructions and settings
@@ -91,3 +92,11 @@ Always include the literal term `SearchAndSummarizeContent` in this section, eve
 In `User stories`, include a functional user story list when it helps explain what the agent does from an end-user or business-process point of view. Derive stories only from the files and from any clarification answers you received. Use concise `As a <user>, I want <capability>, so that <outcome>` phrasing. If the purpose, actor, or outcome is unclear, either ask a clarification question before the final report or include the story under `Open questions and uncertainties` instead of inventing details. If user stories would not add value for a very small or purely technical agent, still include the `User stories` section and say that no meaningful functional user stories were found beyond the basic interaction.
 
 If a section has no matching components, explicitly say none were found.
+
+In `Plain-language summary`, write for the user's approval gate in two parts:
+
+1. **What the agent is for (high level).** One short paragraph: the agent's overall purpose and who uses it. Keep general goals (e.g., "answers regional HR questions") here, not in the journeys.
+
+2. **Capabilities (behavior-focused).** Present the agent's capabilities as a table, not micro-steps. The left column is the capability, phrased from the agent's perspective as something the agent does — use agent-as-actor verbs, not the user's point of view (e.g., "Retrieves the user's cases", not "View my cases"; "Answers HR/travel questions"; "Identifies the user and their country"; "Responds in the user's language"; "Creates and tracks HR cases"; "Looks up a case"; "Retrieves approvals and tasks"; "Handles unrecognized requests"). Include both user-initiated capabilities and always-on/cross-cutting ones (sign-in, language handling, formatting) — they are capabilities, not intents. The right column, `Behavior`, describes what the agent does and the decision logic behind it in plain language — not the internal mechanism. Do not name variables, connectors, flows, prompts, or topics; describe the logic (e.g., "uses the employee's country to pick the right regional knowledge and answers in their language"). Spell out conditions in full sentences — e.g., "case creation is only offered to employees in supported countries; others are told it isn't available for their country". Columns: `Capability` and `Behavior`. Trace cause-and-effect so the reader sees how the start-of-conversation context (country, detected language) shapes later answers. Keep general goals out of the rows (they belong in part 1). Where behavior is unclear from the files, say so rather than inventing it.
+
+End this section with an explicit `Open gaps:` line — list every decision, assumption, ambiguity, or non-migratable component that needs human resolution (e.g., redundant routing approaches, flows that cannot be auto-migrated), or state `Open gaps: none`. Do not hide uncertainties; anything unresolved must also appear under `Open questions and uncertainties`.

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -1,7 +1,7 @@
 ---
 description: Migrate a Copilot Studio agent from the previous architecture to the new agentic loop, cloning it first if it is not already present locally.
 argument-hint: Agent name or path to describe (and source environment if it must be cloned)
-allowed-tools: Bash(pac), Bash(node *convert-actions-to-tools.js*), Read, Glob, Grep, Task
+allowed-tools: Bash(pac), Bash(node *convert-actions-to-tools.js*), Read, Write, Glob, Grep, Task
 ---
 
 # Copilot Studio Agent Migration
@@ -13,6 +13,16 @@ Initial request: $ARGUMENTS
 ---
 
 ## Core Process
+
+### Resumability
+
+Run the execution steps in their natural order, exactly as described below (tool migration → architect → push); each step depends on the previous one's output. You do not need a separate todo list to track this — the steps and the plan file below are the source of truth.
+
+Persist the approved plan so a stopped migration can be resumed:
+
+- When the user approves the migration plan (step 5a), write it to a Markdown file named `MIGRATION-PLAN-<random>.md`, where `<random>` is a short random string (e.g. 6-8 hex/alphanumeric chars) used only to keep the filename unique. Write it as a **sibling of the target project directory** (i.e., in the parent folder, next to the project — not inside it) so it is never packed or pushed with the agent.
+- Update that same file after each subsequent major step completes (tool migration, architect, push), so it always reflects current state.
+- At the start of a `/migrate` run, look for an existing `MIGRATION-PLAN-*.md` sibling to the resolved target/source workspace. If one exists and its plan is already approved, offer to resume from the next incomplete step instead of re-running describe and plan approval. If it exists but is not yet approved, re-present it for approval. If none exists, start fresh.
 
 ### 1. Ensure prerequisites
 
@@ -52,7 +62,20 @@ After the init sub-agent completes, confirm the target agent's `settings.mcs.yml
 
 ### 5. Describe the source agent
 
-With the source agent available locally, delegate the description to the **Copilot Studio Describer** sub-agent (you MUST use the best of the bests AI model, high reasoning effort). Give it the selected source agent path explicitly, not the newly initialized target agent path. It is read-only: it reads the source agent's files, asks any needed clarification questions, and produces a detailed descriptive report, that will be later used by the architect sub-agent to implement the migrated agent YAML.
+With the source agent available locally, delegate the description to the **Copilot Studio Describer** sub-agent (you MUST use the best of the bests AI model, high reasoning effort). Give it the selected source agent path explicitly, not the newly initialized target agent path. It is read-only: it reads the source agent's files, asks any needed clarification questions, and produces a detailed descriptive report, that will be later used by the architect sub-agent to implement the migrated agent YAML. Run the describer in the background so you can keep its session alive for iteration in the next step.
+
+### 5a. Review and approve the migration plan (mandatory gate)
+
+Before any tool migration or YAML implementation, the user must approve a **migration plan** derived from the description. This is a single iterative loop, not a set of discrete questions: you present one consolidated plan, the user approves or comments, and you re-present the whole updated plan each round until they confirm. The architect MUST NOT run until the user approves the plan.
+
+1. **Build the plan from the description.** Using the describer's report, assemble one consolidated artifact that describes the agent being built, not just the legacy one. Make clear throughout that these capabilities are what the **new (migrated) agent will have** — i.e., what is being carried over and built into the modern agent. Include these parts:
+   - **What the new agent is for** — the one-paragraph high-level summary, framed as the purpose of the migrated agent.
+   - **Capabilities of the new agent** — the `Capability` vs `Behavior` table, presented as the capabilities that will become part of the migrated agent. State explicitly that approving the plan means these become the modern agent's capabilities. The `Capability` column is phrased from the agent's perspective using agent-as-actor verbs (e.g., "Retrieves the user's cases", not "View my cases"), covering both user-initiated capabilities and always-on ones (identifies user & country, handles language, formatting). The `Behavior` column describes what the agent does and its decision logic in plain language (no variables, connectors, flows, or topic names) and how the start-of-conversation context (country, language) shapes later answers.
+   - **Migration plan** — for each open gap the describer surfaced (e.g., duplicate regional knowledge as topics vs sub-agents, non-migratable ServiceNow flows, language handling, country allow-lists, cleanup), propose how to handle it in the migration with a recommended approach, not just an open question. Make these proposals concrete so the user can react to a plan rather than start from a blank page.
+   - Offer the full describer report on request.
+2. **Present the whole plan and ask for approval** using the `ask_user` tool. Offer only two explicit choices — **Approve** (proceed to migration) and **Stop** — plus the free-text "Other" option that `ask_user` provides. Do not add a separate "request changes" choice: the free-text "Other" already lets the user request changes or comment on any part of the plan (description corrections, a different gap resolution, added guidance). Make the prompt clear that typing in "Other" is how to request changes.
+3. **Iterate on comments.** If the user requests changes via the free-text answer, apply their feedback: for description corrections, send the feedback to the existing describer sub-agent (via `write_agent`) so it refines the same report with full context; for plan/gap-handling changes, update the proposals directly. Then re-present the **entire** plan in full again — the complete "what the new agent is for" paragraph, the full capabilities table with every row rendered, and the full migration plan — with the requested changes already applied. Do NOT show a diff, delta, or shorthand such as "same as above, minus the X row"; always render the whole updated plan from top to bottom so the user reviews the complete current state each round. Then ask for approval once more. Repeat until the user approves or stops.
+4. Capture the approved plan — including the agreed handling for every gap — to pass forward to the architect as explicit decisions, not guesses. On approval, write the full plan to the sibling `MIGRATION-PLAN-<random>.md` file (see "Resumability") so it can be resumed or used as the architect's input spec. Only after the user approves the plan, continue to tool migration and implementation.
 
 ### 6. Migrate tools and actions
 The tool migration process converts the legacy YAML format of actions (located in the \actions folder in the legacy agent) to the new format (to be placed in capabilities\tools in the new agent). The procedure is as follows:
@@ -62,7 +85,7 @@ Step 3: Run the migration script. Execute the migration script: node scripts\con
 The script will convert all connector and MCP servers, but will automatically skip any workflows, AI Prompts, or other unsupported actions. If the script encounters unsupported actions, do not worry. Capture the converted-tool summary and the skipped unsupported action list, then pass both to the Architect agent in the subsequent step so that the behavior can be manually refactored into instructions, skills, knowledge, or explicit open gaps.
 
 ### 7. Implement the migrated agent YAML
-After the describer produces its report and tool/action migration is complete, give the agent description as input specs for the **Copilot Studio Architect** sub-agent (you MUST use the best of the bests AI model, high reasoning effort), and ask it to modify the newly initialized modern agent project directly.
+After the user has approved the migration plan (step 5a) and tool/action migration is complete, give the agent description as input specs for the **Copilot Studio Architect** sub-agent (you MUST use the best of the bests AI model, high reasoning effort), and ask it to modify the newly initialized modern agent project directly.
 
 The architect sub-agent must receive:
 
@@ -70,8 +93,9 @@ The architect sub-agent must receive:
 2. The newly initialized target agent project directory.
 3. The migrated target display name (`NEW <source displayName>`).
 4. The target environment ID.
-5. The complete Copilot Studio Describer report.
+5. The complete Copilot Studio Describer report and the approved migration plan (including the agreed handling for every gap).
 6. The tool/action migration result, including migrated tools and unsupported skipped actions.
+7. The user's decisions on the open gaps, as captured in the approved plan (step 5a).
 
 Tell the architect explicitly that the final migration artifact is the YAML written under the target project directory. If the describer report identifies gaps or uncertainties in understanding the original agent, discuss implementation strategies with the user before proceeding, and highlight those to the architect so it can make reasonable assumptions where needed to complete the YAML implementation, while listing any unresolved gaps in its final response.
 


### PR DESCRIPTION
## Summary

Adds a mandatory, iterative migration-plan approval gate to the `/migrate` workflow, plus a resumable plan file. Scoped to the approval workflow only — the separate .NET/pac prerequisites fix is intentionally not part of this branch.

### commands/migrate.md
- New **step 5a**: a single iterative approve/comment/stop loop. Builds one consolidated migration plan from the describer report (purpose paragraph + Capability/Behavior table framed as the *new* agent's capabilities + per-gap recommended resolutions), re-renders the full plan each round, and gates the architect (step 7) on approval.
- Describer now runs in the background so its session stays alive for iteration.
- **Resumability**: on approval, the plan is written to a sibling `MIGRATION-PLAN-<random>.md` (never pushed with the agent) and updated after each major step; a run resumes from it if present.
- Architect now receives the approved plan and the user's gap decisions as explicit inputs.
- `Write` added to allowed-tools.

### agents/copilot-studio-describer.md
- Plain-language summary is now a mandatory section written for the approval gate: a high-level purpose paragraph + a Capability/Behavior table (agent-as-actor verbs, no internal mechanisms) + an explicit `Open gaps:` line.

### Notes
- No regressions to the prior happy path; the one intended behavior change is that the architect no longer runs fully unattended — it waits for human plan approval.
- The .NET 10 / `DOTNET_ROOT` prerequisites documentation that was briefly bundled here has been stripped so this branch only documents behavior it actually implements.