### PR TITLE
Make action migration selectable

### DIFF
--- a/agents/copilot-studio-architect.md
+++ b/agents/copilot-studio-architect.md
@@ -94,7 +94,7 @@ You need these inputs before implementing a migrated agent:
 2. Detailed behavior report from the Copilot Studio Describer.
 3. Target migrated agent display name.
 4. Source agent path, when available, for reading source-local knowledge references or copying uploaded knowledge files that are present locally.
-5. Tool/action migration result, including which tools were already converted into `capabilities\tools` and which legacy actions were skipped as unsupported.
+5. Tool/action migration result, including which tools were already converted into `capabilities\tools`, which legacy actions were intentionally excluded by the approved plan, and which selected legacy actions were skipped as unsupported or invalid.
 
 If the target project directory or describer report is missing, ask for the missing value and stop. If source files or unsupported action details are missing, continue with reasonable assumptions and list the gap in the final response.
 
@@ -104,7 +104,7 @@ If the target project directory or describer report is missing, ask for the miss
 - Never modify the source agent folder.
 - Do not hand-edit files under `.mcs\`; they are CLI-managed state.
 - Preserve initialized identity fields such as `schemaName`, environment binding, connection references, template, language, and generated IDs unless the user explicitly asks for an identity change.
-- Preserve any already migrated files under `capabilities\tools`. Read them so instructions and skills can reference the available tools correctly. Do not overwrite connector or MCP tool YAML unless you have complete, concrete YAML fields and the change is required by the migration.
+- Preserve any already migrated files under `capabilities\tools`. Read them so instructions and skills can reference the available tools correctly. Do not overwrite connector or MCP tool YAML unless you have complete, concrete YAML fields and the change is required by the migration. Treat actions intentionally excluded by the approved migration plan as out of scope, not as missing tools to recreate.
 - Do not create design notes, migration plans, or JSON meta-description files in the project. The final implementation artifact is the YAML component set.
 
 ## Project structure and YAML conventions
@@ -201,7 +201,7 @@ toolInputs:
       defaultValue: "\"user@example.com\""
 ```
 
-Only create or substantially modify tool YAML when the describer report or migrated action output provides complete connector/MCP details such as connector ID, operation ID, auth mode, inputs, outputs, and connection reference. Otherwise, represent the intended tool use in instructions or a skill that calls the already migrated tools, and list unsupported skipped actions as gaps that require manual tool authoring.
+Only create or substantially modify tool YAML when the describer report or migrated action output provides complete connector/MCP details such as connector ID, operation ID, auth mode, inputs, outputs, and connection reference. Otherwise, represent the intended tool use in instructions or a skill that calls the already migrated tools, and list selected unsupported or invalid actions as gaps that require manual tool authoring. Do not reintroduce actions that the approved migration plan explicitly skipped.
 
 ## Skill YAML
 
@@ -473,7 +473,7 @@ Keep the final answer short and factual. Include:
 1. The target project directory.
 2. The target YAML files or component areas changed.
 3. Migrated tools that were preserved and referenced.
-4. Assumptions made and unresolved gaps, especially unsupported skipped legacy actions or missing knowledge sources.
+4. Assumptions made and unresolved gaps, especially selected unsupported legacy actions, invalid selected actions, or missing knowledge sources.
 5. Validation outcome if validation was run.
 
 Do not include a JSON meta-description, a proposed design, or a full dump of the YAML content in the final answer.

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -76,7 +76,7 @@ Before building the user-approved migration plan, inspect the legacy action file
 node scripts\convert-actions-to-tools.js <legacy-actions-folder> --list
 ```
 
-Use the inventory and the describer report together to identify every legacy action's source file name, display/component name, support status, and likely relevance to the modern agent. The source file name is the stable selector to use later with `--include` or `--exclude`.
+Use the inventory and the describer report together to identify every legacy action's source file name, whole `mcs.metadata` object, `modelDisplayName`, `modelDescription`, `action.operationId`, support status, and likely relevance to the modern agent. The source file name is the stable selector to use later with `--include` or `--exclude`.
 
 ### 5b. Review and approve the migration plan (mandatory gate)
 
@@ -85,7 +85,7 @@ Before any tool migration or YAML implementation, the user must approve a **migr
 1. **Build the plan from the description.** Using the describer's report, assemble one consolidated artifact that describes the agent being built, not just the legacy one. Make clear throughout that these capabilities are what the **new (migrated) agent will have** — i.e., what is being carried over and built into the modern agent. Include these parts:
    - **What the new agent is for** — the one-paragraph high-level summary, framed as the purpose of the migrated agent.
    - **Capabilities of the new agent** — the `Capability` vs `Behavior` table, presented as the capabilities that will become part of the migrated agent. State explicitly that approving the plan means these become the modern agent's capabilities. The `Capability` column is phrased from the agent's perspective using agent-as-actor verbs (e.g., "Retrieves the user's cases", not "View my cases"), covering both user-initiated capabilities and always-on ones (identifies user & country, handles language, formatting). The `Behavior` column describes what the agent does and its decision logic in plain language (no variables, connectors, flows, or topic names) and how the start-of-conversation context (country, language) shapes later answers.
-   - **Tool/action migration decisions** — for each legacy action from step 5a, include a table with the action file name, display/component name, support status, approved decision, and rationale. Use these decisions:
+   - **Tool/action migration decisions** — for each legacy action from step 5a, include a table with the action file name, the most important inventory fields (`mcs.metadata`, `modelDisplayName`, `modelDescription`, and `action.operationId`), support status, approved decision, and rationale. Use these decisions:
      - `migrate`: convert this action into a modern tool.
      - `skip`: intentionally exclude this action/capability from the modern agent.
      - `manual`: do not auto-convert; the architect should implement the behavior another way or list it as a gap.

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -64,28 +64,73 @@ After the init sub-agent completes, confirm the target agent's `settings.mcs.yml
 
 With the source agent available locally, delegate the description to the **Copilot Studio Describer** sub-agent (you MUST use the best of the bests AI model, high reasoning effort). Give it the selected source agent path explicitly, not the newly initialized target agent path. It is read-only: it reads the source agent's files, asks any needed clarification questions, and produces a detailed descriptive report, that will be later used by the architect sub-agent to implement the migrated agent YAML. Run the describer in the background so you can keep its session alive for iteration in the next step.
 
-### 5a. Review and approve the migration plan (mandatory gate)
+### 5a. Inventory legacy actions for plan input
+
+Before building the user-approved migration plan, inspect the legacy action files so tool selection is decided in the same approval loop as all other migration scope decisions.
+
+1. Check for an `actions` folder in the selected source agent path.
+2. If the folder does not exist, note in the migration plan that no legacy actions were found.
+3. If the folder exists, run the inventory command:
+
+```bash
+node scripts\convert-actions-to-tools.js <legacy-actions-folder> --list
+```
+
+Use the inventory and the describer report together to identify every legacy action's source file name, display/component name, support status, and likely relevance to the modern agent. The source file name is the stable selector to use later with `--include` or `--exclude`.
+
+### 5b. Review and approve the migration plan (mandatory gate)
 
 Before any tool migration or YAML implementation, the user must approve a **migration plan** derived from the description. This is a single iterative loop, not a set of discrete questions: you present one consolidated plan, the user approves or comments, and you re-present the whole updated plan each round until they confirm. The architect MUST NOT run until the user approves the plan.
 
 1. **Build the plan from the description.** Using the describer's report, assemble one consolidated artifact that describes the agent being built, not just the legacy one. Make clear throughout that these capabilities are what the **new (migrated) agent will have** — i.e., what is being carried over and built into the modern agent. Include these parts:
    - **What the new agent is for** — the one-paragraph high-level summary, framed as the purpose of the migrated agent.
    - **Capabilities of the new agent** — the `Capability` vs `Behavior` table, presented as the capabilities that will become part of the migrated agent. State explicitly that approving the plan means these become the modern agent's capabilities. The `Capability` column is phrased from the agent's perspective using agent-as-actor verbs (e.g., "Retrieves the user's cases", not "View my cases"), covering both user-initiated capabilities and always-on ones (identifies user & country, handles language, formatting). The `Behavior` column describes what the agent does and its decision logic in plain language (no variables, connectors, flows, or topic names) and how the start-of-conversation context (country, language) shapes later answers.
+   - **Tool/action migration decisions** — for each legacy action from step 5a, include a table with the action file name, display/component name, support status, approved decision, and rationale. Use these decisions:
+     - `migrate`: convert this action into a modern tool.
+     - `skip`: intentionally exclude this action/capability from the modern agent.
+     - `manual`: do not auto-convert; the architect should implement the behavior another way or list it as a gap.
+     - `unsupported`: the action cannot be auto-converted; pass it to the architect for manual refactor or gap handling if the capability remains in scope.
    - **Migration plan** — for each open gap the describer surfaced (e.g., duplicate regional knowledge as topics vs sub-agents, non-migratable ServiceNow flows, language handling, country allow-lists, cleanup), propose how to handle it in the migration with a recommended approach, not just an open question. Make these proposals concrete so the user can react to a plan rather than start from a blank page.
    - Offer the full describer report on request.
 2. **Present the whole plan and ask for approval** using the `ask_user` tool. Offer only two explicit choices — **Approve** (proceed to migration) and **Stop** — plus the free-text "Other" option that `ask_user` provides. Do not add a separate "request changes" choice: the free-text "Other" already lets the user request changes or comment on any part of the plan (description corrections, a different gap resolution, added guidance). Make the prompt clear that typing in "Other" is how to request changes.
 3. **Iterate on comments.** If the user requests changes via the free-text answer, apply their feedback: for description corrections, send the feedback to the existing describer sub-agent (via `write_agent`) so it refines the same report with full context; for plan/gap-handling changes, update the proposals directly. Then re-present the **entire** plan in full again — the complete "what the new agent is for" paragraph, the full capabilities table with every row rendered, and the full migration plan — with the requested changes already applied. Do NOT show a diff, delta, or shorthand such as "same as above, minus the X row"; always render the whole updated plan from top to bottom so the user reviews the complete current state each round. Then ask for approval once more. Repeat until the user approves or stops.
-4. Capture the approved plan — including the agreed handling for every gap — to pass forward to the architect as explicit decisions, not guesses. On approval, write the full plan to the sibling `MIGRATION-PLAN-<random>.md` file (see "Resumability") so it can be resumed or used as the architect's input spec. Only after the user approves the plan, continue to tool migration and implementation.
+4. Capture the approved plan — including the agreed handling for every gap and every tool/action migration decision — to pass forward to the architect as explicit decisions, not guesses. On approval, write the full plan to the sibling `MIGRATION-PLAN-<random>.md` file (see "Resumability") so it can be resumed or used as the architect's input spec. Only after the user approves the plan, continue to tool migration and implementation.
 
 ### 6. Migrate tools and actions
-The tool migration process converts the legacy YAML format of actions (located in the \actions folder in the legacy agent) to the new format (to be placed in capabilities\tools in the new agent). The procedure is as follows:
-Step 1: Check for legacy actions. Verify if the \actions folder exists in the legacy agent. If it does not exist, no actions need to be migrated; you can proceed directly to the next steps of the migration.
-Step 2: Prepare the destination folder. If the \actions folder exists, check if the capabilities\tools folder exists in the new agent. If it does not exist, create it.
-Step 3: Run the migration script. Execute the migration script: node scripts\convert-actions-to-tools.js <legacy-actions-folder> <new-tools-folder>
-The script will convert all connector and MCP servers, but will automatically skip any workflows, AI Prompts, or other unsupported actions. If the script encounters unsupported actions, do not worry. Capture the converted-tool summary and the skipped unsupported action list, then pass both to the Architect agent in the subsequent step so that the behavior can be manually refactored into instructions, skills, knowledge, or explicit open gaps.
+The tool migration process converts only the approved legacy actions from the `MIGRATION-PLAN-<random>.md` tool/action decisions table.
+
+Step 1: Check the approved plan. If there are no actions with the `migrate` decision, do not run the converter. Record in the plan that no tools were auto-migrated, and carry any `manual` or `unsupported` decisions forward to the architect.
+
+Step 2: Prepare the destination folder. If there are approved actions to migrate, check if the `capabilities\tools` folder exists in the new agent. If it does not exist, create it.
+
+Step 3: Run the migration script using one command derived from the approved decisions:
+
+- To migrate all directly supported actions, run:
+
+```bash
+node scripts\convert-actions-to-tools.js <legacy-actions-folder> <new-tools-folder> --all --report <tool-migration-report-json>
+```
+
+- To migrate a selected subset, pass the approved action file names after `--include`:
+
+```bash
+node scripts\convert-actions-to-tools.js <legacy-actions-folder> <new-tools-folder> --include "<action-file-1.mcs.yml>" "<action-file-2.mcs.yml>" --report <tool-migration-report-json>
+```
+
+- If the approved plan keeps almost every supported action except a few, you may instead use `--exclude` with the omitted action file names:
+
+```bash
+node scripts\convert-actions-to-tools.js <legacy-actions-folder> <new-tools-folder> --exclude "<skipped-action-file.mcs.yml>" --report <tool-migration-report-json>
+```
+
+Do not use `--clean` with `--include` or `--exclude`; partial migration must not delete tools outside the selected subset.
+
+Step 4: Capture the converted-tool report, including converted tools, unsupported or invalid selected actions, and intentionally excluded actions. Update the sibling `MIGRATION-PLAN-<random>.md` file with the tool migration result before proceeding.
+
+The script will convert supported connector and MCP actions, but will automatically skip workflows, AI Prompts, or other unsupported actions. If selected actions are unsupported, do not treat that as a failure by itself. Capture the skipped unsupported action list and pass it to the Architect agent so that the behavior can be manually refactored into instructions, skills, knowledge, or explicit open gaps.
 
 ### 7. Implement the migrated agent YAML
-After the user has approved the migration plan (step 5a) and tool/action migration is complete, give the agent description as input specs for the **Copilot Studio Architect** sub-agent (you MUST use the best of the bests AI model, high reasoning effort), and ask it to modify the newly initialized modern agent project directly.
+After the user has approved the migration plan (step 5b) and tool/action migration is complete, give the agent description as input specs for the **Copilot Studio Architect** sub-agent (you MUST use the best of the bests AI model, high reasoning effort), and ask it to modify the newly initialized modern agent project directly.
 
 The architect sub-agent must receive:
 
@@ -93,9 +138,9 @@ The architect sub-agent must receive:
 2. The newly initialized target agent project directory.
 3. The migrated target display name (`NEW <source displayName>`).
 4. The target environment ID.
-5. The complete Copilot Studio Describer report and the approved migration plan (including the agreed handling for every gap).
-6. The tool/action migration result, including migrated tools and unsupported skipped actions.
-7. The user's decisions on the open gaps, as captured in the approved plan (step 5a).
+5. The complete Copilot Studio Describer report and the approved migration plan (including the agreed handling for every gap and every tool/action decision).
+6. The tool/action migration result, including migrated tools, intentionally excluded actions, unsupported skipped actions, and invalid selected actions.
+7. The user's decisions on the open gaps, as captured in the approved plan (step 5b).
 
 Tell the architect explicitly that the final migration artifact is the YAML written under the target project directory. If the describer report identifies gaps or uncertainties in understanding the original agent, discuss implementation strategies with the user before proceeding, and highlight those to the architect so it can make reasonable assumptions where needed to complete the YAML implementation, while listing any unresolved gaps in its final response.
 

--- a/scripts/convert-actions-to-tools.js
+++ b/scripts/convert-actions-to-tools.js
@@ -16,10 +16,13 @@ function usage() {
   console.error(
     [
       "Usage:",
-      "  node convert-actions-to-tools.js <legacy-actions-folder> <new-tools-folder> [--clean]",
+      "  node convert-actions-to-tools.js <legacy-actions-folder> <new-tools-folder> [--all] [--include <action-file...>] [--exclude <action-file...>] [--report <path>] [--clean]",
+      "  node convert-actions-to-tools.js <legacy-actions-folder> --list [--include <action-file...>] [--exclude <action-file...>] [--report <path>]",
       "",
-      "Example:",
+      "Examples:",
       "  node convert-actions-to-tools.js \"C:\\Users\\gughini\\CopilotStudio\\SST\\actions\" \"C:\\Users\\gughini\\CopilotStudio\\dragent\\Giorgio2Clone\\capabilities\\tools\" --clean",
+      "  node convert-actions-to-tools.js \"C:\\Users\\gughini\\CopilotStudio\\SST\\actions\" \"C:\\Users\\gughini\\CopilotStudio\\dragent\\Giorgio2Clone\\capabilities\\tools\" --include \"SQLServer-ExecuteaSQLqueryV2.mcs.yml\" \"Dataverse-Listrows.mcs.yml\" --report tools-report.json",
+      "  node convert-actions-to-tools.js \"C:\\Users\\gughini\\CopilotStudio\\SST\\actions\" --list --report action-inventory.json",
     ].join("\n"),
   );
 }
@@ -251,16 +254,11 @@ function inferConnectorId(connectionReference) {
   return match ? `/providers/Microsoft.PowerApps/apis/${match[1]}` : undefined;
 }
 
-function randomSuffix() {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  let suffix = "";
-  for (let index = 0; index < 3; index += 1) {
-    suffix += chars[crypto.randomInt(chars.length)];
-  }
-  return suffix;
+function stableSuffix(inputFileName) {
+  return crypto.createHash("sha256").update(inputFileName).digest("hex").slice(0, 6);
 }
 
-function outputFileName(inputFileName, existingNames) {
+function outputFileName(inputFileName) {
   const specialExtension = inputFileName.endsWith(".mcs.yml")
     ? ".mcs.yml"
     : inputFileName.endsWith(".mcs.yaml")
@@ -268,13 +266,7 @@ function outputFileName(inputFileName, existingNames) {
       : path.extname(inputFileName);
   const baseName = inputFileName.slice(0, inputFileName.length - specialExtension.length);
 
-  let candidate;
-  do {
-    candidate = `${baseName}_${randomSuffix()}${specialExtension}`;
-  } while (existingNames.has(candidate));
-
-  existingNames.add(candidate);
-  return candidate;
+  return `${baseName}_${stableSuffix(inputFileName)}${specialExtension}`;
 }
 
 function baseMetadata(document, fallbackName) {
@@ -376,6 +368,71 @@ function convertTaskDialog(document) {
   return { skipped: `Unsupported action kind '${action.kind || "unknown"}'` };
 }
 
+function actionOperationId(action) {
+  return action.operationId || action.operationDetails?.operationId;
+}
+
+function supportStatus(result) {
+  if (!result.skipped) return "convertible";
+  if (result.skipped.includes("missing")) return "invalid";
+  return "unsupported";
+}
+
+function inventoryInput(input) {
+  const result = {
+    kind: input.kind,
+    propertyName: input.propertyName,
+  };
+  if (Object.prototype.hasOwnProperty.call(input, "value")) {
+    result.defaultValue = input.value;
+  }
+  return result;
+}
+
+function inventoryOutput(output) {
+  return {
+    propertyName: output.propertyName,
+    name: output.name,
+  };
+}
+
+function inventoryEntry(fileName, document, result) {
+  const metadata = baseMetadata(document, "Unknown action");
+  const action = document.action || {};
+  const entry = {
+    fileName,
+    componentName: metadata.componentName,
+    modelDisplayName: document.modelDisplayName,
+    modelDescription: document.modelDescription,
+    kind: document.kind,
+    actionKind: action.kind,
+    connectionReference: action.connectionReference,
+    connectorId: inferConnectorId(action.connectionReference),
+    operationId: actionOperationId(action),
+    inputs: Array.isArray(document.inputs) ? document.inputs.map(inventoryInput) : [],
+    outputs: Array.isArray(document.outputs) ? document.outputs.map(inventoryOutput) : [],
+    supportStatus: supportStatus(result),
+  };
+
+  if (result.skipped) {
+    entry.reason = result.skipped;
+  }
+
+  return entry;
+}
+
+function readAction(sourceFolder, fileName) {
+  const sourcePath = path.join(sourceFolder, fileName);
+  const text = fs.readFileSync(sourcePath, "utf8");
+  const document = parseYaml(text);
+  const result = convertTaskDialog(document);
+  return {
+    document,
+    result,
+    inventory: inventoryEntry(fileName, document, result),
+  };
+}
+
 function cleanOutputFolder(outputFolder) {
   if (!fs.existsSync(outputFolder)) return 0;
   let deleted = 0;
@@ -387,48 +444,273 @@ function cleanOutputFolder(outputFolder) {
   return deleted;
 }
 
-const args = process.argv.slice(2);
-const clean = args.includes("--clean");
-const folders = args.filter((arg) => arg !== "--clean");
+function optionValues(args, index, optionName) {
+  const values = [];
+  let cursor = index + 1;
+  while (cursor < args.length && !args[cursor].startsWith("--")) {
+    values.push(args[cursor]);
+    cursor += 1;
+  }
 
-if (folders.length !== 2) {
+  if (values.length === 0) {
+    throw new Error(`${optionName} requires at least one action file name.`);
+  }
+
+  return { values, nextIndex: cursor };
+}
+
+function parseArgs(args) {
+  const options = {
+    all: false,
+    clean: false,
+    exclude: [],
+    folders: [],
+    include: [],
+    list: false,
+    reportPath: undefined,
+  };
+
+  for (let index = 0; index < args.length;) {
+    const arg = args[index];
+    if (arg === "--all") {
+      options.all = true;
+      index += 1;
+      continue;
+    }
+    if (arg === "--clean") {
+      options.clean = true;
+      index += 1;
+      continue;
+    }
+    if (arg === "--list") {
+      options.list = true;
+      index += 1;
+      continue;
+    }
+    if (arg === "--report") {
+      const reportPath = args[index + 1];
+      if (!reportPath || reportPath.startsWith("--")) {
+        throw new Error("--report requires a path.");
+      }
+      options.reportPath = reportPath;
+      index += 2;
+      continue;
+    }
+    if (arg === "--include") {
+      const { values, nextIndex } = optionValues(args, index, "--include");
+      options.include.push(...values);
+      index = nextIndex;
+      continue;
+    }
+    if (arg === "--exclude") {
+      const { values, nextIndex } = optionValues(args, index, "--exclude");
+      options.exclude.push(...values);
+      index = nextIndex;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+
+    options.folders.push(arg);
+    index += 1;
+  }
+
+  if (options.all && options.include.length > 0) {
+    throw new Error("--all cannot be combined with --include.");
+  }
+
+  return options;
+}
+
+function selectorFileName(selector) {
+  return path.basename(selector);
+}
+
+function selectorSet(selectors, sourceFiles, optionName) {
+  const available = new Set(sourceFiles);
+  const normalized = selectors.map(selectorFileName);
+  const unknown = [...new Set(normalized.filter((fileName) => !available.has(fileName)))];
+  if (unknown.length > 0) {
+    throw new Error(`${optionName} action file(s) not found: ${unknown.join(", ")}`);
+  }
+  return new Set(normalized);
+}
+
+function selectedSourceFiles(sourceFiles, includeSet, excludeSet) {
+  const selected = [];
+  const excluded = [];
+  for (const fileName of sourceFiles) {
+    if (includeSet.size > 0 && !includeSet.has(fileName)) {
+      excluded.push({ fileName, reason: "Not selected by --include" });
+      continue;
+    }
+    if (excludeSet.has(fileName)) {
+      excluded.push({ fileName, reason: "Excluded by --exclude" });
+      continue;
+    }
+    selected.push(fileName);
+  }
+  return { selected, excluded };
+}
+
+function printInventory(inventory) {
+  if (inventory.length === 0) {
+    console.log("No legacy action YAML files found.");
+    return;
+  }
+
+  console.log("Legacy action inventory:");
+  for (const entry of inventory) {
+    const displayName = entry.componentName || entry.modelDisplayName || "(unnamed action)";
+    const actionKind = entry.actionKind || entry.kind || "unknown";
+    const status = entry.supportStatus === "convertible"
+      ? "convertible"
+      : `${entry.supportStatus}: ${entry.reason}`;
+    console.log(`- ${entry.fileName}: ${displayName} [${actionKind}] ${status}`);
+  }
+}
+
+function writeReport(reportPath, report) {
+  const resolvedReportPath = path.resolve(reportPath);
+  fs.mkdirSync(path.dirname(resolvedReportPath), { recursive: true });
+  fs.writeFileSync(resolvedReportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  console.log(`Wrote report ${resolvedReportPath}`);
+}
+
+function reportFilters(options, includeSet, excludeSet) {
+  return {
+    all: options.all || includeSet.size === 0,
+    include: [...includeSet],
+    exclude: [...excludeSet],
+  };
+}
+
+let options;
+try {
+  options = parseArgs(process.argv.slice(2));
+} catch (error) {
+  console.error(error.message);
   usage();
   process.exit(1);
 }
 
-const [sourceFolder, outputFolder] = folders.map((folder) => path.resolve(folder));
+if (options.list) {
+  if (options.folders.length < 1 || options.folders.length > 2 || options.clean) {
+    usage();
+    process.exit(1);
+  }
+} else if (options.folders.length !== 2) {
+  usage();
+  process.exit(1);
+}
+
+const sourceFolder = path.resolve(options.folders[0]);
+const outputFolder = options.folders[1] ? path.resolve(options.folders[1]) : undefined;
 if (!fs.existsSync(sourceFolder) || !fs.statSync(sourceFolder).isDirectory()) {
   console.error(`Source folder does not exist or is not a directory: ${sourceFolder}`);
   process.exit(1);
 }
 
-fs.mkdirSync(outputFolder, { recursive: true });
-const deleted = clean ? cleanOutputFolder(outputFolder) : 0;
-const existingNames = new Set(fs.readdirSync(outputFolder));
 const sourceFiles = fs
   .readdirSync(sourceFolder)
   .filter((fileName) => /\.ya?ml$/i.test(fileName))
   .sort((left, right) => left.localeCompare(right));
 
-let converted = 0;
-let skipped = 0;
+let includeSet;
+let excludeSet;
+try {
+  includeSet = selectorSet(options.include, sourceFiles, "--include");
+  excludeSet = selectorSet(options.exclude, sourceFiles, "--exclude");
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
 
-for (const fileName of sourceFiles) {
-  const sourcePath = path.join(sourceFolder, fileName);
-  const text = fs.readFileSync(sourcePath, "utf8");
-  const document = parseYaml(text);
-  const result = convertTaskDialog(document);
+if (options.clean && (includeSet.size > 0 || excludeSet.size > 0)) {
+  console.error("--clean cannot be used with --include or --exclude because it would delete tools outside the selected subset.");
+  process.exit(1);
+}
+
+const { selected, excluded } = selectedSourceFiles(sourceFiles, includeSet, excludeSet);
+const actionData = new Map(sourceFiles.map((fileName) => [fileName, readAction(sourceFolder, fileName)]));
+const inventory = sourceFiles.map((fileName) => actionData.get(fileName).inventory);
+const inventoryByFileName = new Map(inventory.map((entry) => [entry.fileName, entry]));
+
+if (options.list) {
+  const report = {
+    mode: "list",
+    sourceFolder,
+    filters: reportFilters(options, includeSet, excludeSet),
+    inventory,
+    selectedFiles: selected,
+    excluded: excluded.map(({ fileName, reason }) => ({
+      ...inventoryByFileName.get(fileName),
+      reason,
+    })),
+    totals: {
+      source: sourceFiles.length,
+      selected: selected.length,
+      excluded: excluded.length,
+    },
+  };
+  printInventory(inventory);
+  if (options.reportPath) writeReport(options.reportPath, report);
+  process.exit(0);
+}
+
+fs.mkdirSync(outputFolder, { recursive: true });
+const deleted = options.clean ? cleanOutputFolder(outputFolder) : 0;
+const report = {
+  mode: "migrate",
+  sourceFolder,
+  outputFolder,
+  filters: reportFilters(options, includeSet, excludeSet),
+  converted: [],
+  skippedUnsupported: [],
+  invalid: [],
+  excluded: excluded.map(({ fileName, reason }) => ({
+    ...inventoryByFileName.get(fileName),
+    reason,
+  })),
+};
+
+for (const fileName of selected) {
+  const { result, inventory: entry } = actionData.get(fileName);
 
   if (result.skipped) {
-    skipped += 1;
+    const skippedEntry = { ...entry, reason: result.skipped };
+    if (entry.supportStatus === "invalid") {
+      report.invalid.push(skippedEntry);
+    } else {
+      report.skippedUnsupported.push(skippedEntry);
+    }
     console.warn(`Skipped ${fileName}: ${result.skipped}`);
     continue;
   }
 
-  const targetFileName = outputFileName(fileName, existingNames);
-  fs.writeFileSync(path.join(outputFolder, targetFileName), result.yaml, "utf8");
-  converted += 1;
+  const targetFileName = outputFileName(fileName);
+  const targetPath = path.join(outputFolder, targetFileName);
+  fs.writeFileSync(targetPath, result.yaml, "utf8");
+  report.converted.push({
+    ...entry,
+    targetFileName,
+    targetPath,
+  });
   console.log(`Converted ${fileName} -> ${targetFileName}`);
 }
 
-console.log(`Done. Converted ${converted}, skipped ${skipped}, deleted ${deleted}.`);
+report.totals = {
+  source: sourceFiles.length,
+  selected: selected.length,
+  converted: report.converted.length,
+  skippedUnsupported: report.skippedUnsupported.length,
+  invalid: report.invalid.length,
+  excluded: report.excluded.length,
+  deleted,
+};
+
+console.log(
+  `Done. Converted ${report.totals.converted}, skipped ${report.totals.skippedUnsupported + report.totals.invalid}, excluded ${report.totals.excluded}, deleted ${deleted}.`,
+);
+if (options.reportPath) writeReport(options.reportPath, report);

--- a/scripts/convert-actions-to-tools.js
+++ b/scripts/convert-actions-to-tools.js
@@ -397,10 +397,12 @@ function inventoryOutput(output) {
 }
 
 function inventoryEntry(fileName, document, result) {
+  const mcsMetadata = document["mcs.metadata"] || {};
   const metadata = baseMetadata(document, "Unknown action");
   const action = document.action || {};
   const entry = {
     fileName,
+    "mcs.metadata": mcsMetadata,
     componentName: metadata.componentName,
     modelDisplayName: document.modelDisplayName,
     modelDescription: document.modelDescription,
@@ -554,6 +556,18 @@ function selectedSourceFiles(sourceFiles, includeSet, excludeSet) {
   return { selected, excluded };
 }
 
+function formatInventoryValue(value) {
+  if (value === undefined) return "(not set)";
+  if (value === null) return "null";
+  if (typeof value === "object") return JSON.stringify(value, null, 2);
+  return String(value);
+}
+
+function indentInventoryValue(value, spaces) {
+  const indentation = " ".repeat(spaces);
+  return formatInventoryValue(value).replace(/\n/g, `\n${indentation}`);
+}
+
 function printInventory(inventory) {
   if (inventory.length === 0) {
     console.log("No legacy action YAML files found.");
@@ -562,12 +576,18 @@ function printInventory(inventory) {
 
   console.log("Legacy action inventory:");
   for (const entry of inventory) {
-    const displayName = entry.componentName || entry.modelDisplayName || "(unnamed action)";
     const actionKind = entry.actionKind || entry.kind || "unknown";
     const status = entry.supportStatus === "convertible"
       ? "convertible"
       : `${entry.supportStatus}: ${entry.reason}`;
-    console.log(`- ${entry.fileName}: ${displayName} [${actionKind}] ${status}`);
+    console.log(`- fileName: ${entry.fileName}`);
+    console.log(`  supportStatus: ${status}`);
+    console.log(`  action.kind: ${actionKind}`);
+    console.log("  mcs.metadata:");
+    console.log(`    ${indentInventoryValue(entry["mcs.metadata"], 4)}`);
+    console.log(`  modelDisplayName: ${indentInventoryValue(entry.modelDisplayName, 22)}`);
+    console.log(`  modelDescription: ${indentInventoryValue(entry.modelDescription, 22)}`);
+    console.log(`  action.operationId: ${indentInventoryValue(entry.operationId, 22)}`);
   }
 }
 


### PR DESCRIPTION
Classic-to-modern migrations currently convert every supported legacy action, which makes it hard for the AI coding agent or user-approved migration plan to omit tools that are no longer needed. This change makes tool migration driven by the approved plan while keeping the existing migrate-all path available.

## Summary

- Adds action inventory and selective conversion support to `convert-actions-to-tools.js` with `--list`, multi-file `--include` / `--exclude`, explicit `--all`, structured `--report`, and deterministic output names for reruns.
- Prioritizes the key fields needed to review long action YAMLs in inventory output: full `mcs.metadata`, `modelDisplayName`, `modelDescription`, and `action.operationId`.
- Updates `/migrate` so legacy action decisions are captured in the existing `MIGRATION-PLAN-<random>.md` approval flow instead of asking for a second approval or using a separate selection file.
- Updates architect guidance so intentionally skipped actions are treated as out of scope, while selected unsupported or invalid actions are carried forward as manual refactor gaps.

## Validation

- `node --check scripts\convert-actions-to-tools.js`
- Smoke-checked list, include, report generation, rerun/idempotent output behavior, exclude, and the partial-migration `--clean` guard.
- Smoke-checked inventory output/reporting for `mcs.metadata`, `modelDisplayName`, `modelDescription`, and `action.operationId`.