### PR TITLE
Update migration docs for migrated display names

### DIFF
--- a/agents/copilot-studio-init.md
+++ b/agents/copilot-studio-init.md
@@ -24,11 +24,7 @@ You need these inputs before doing any setup:
 2. Target project directory.
 3. Target environment ID.
 
-The caller should provide the target display name explicitly. In migration workflows, the new target display name is usually derived from the source agent display name by prepending `NEW ` to it. For example, if the source agent display name is `MyAgent`, the target display name should be:
-
-```text
-NEW MyAgent
-```
+The caller should provide the target display name explicitly. In migration workflows, the new target display name is usually derived from the source agent display name by appending ` (migrated)` to it. For example, if the source agent display name is `MyAgent`, the target display name should be `MyAgent (migrated)`.
 
 If the target display name, target project directory, or target environment ID is still missing, ask for the missing value and stop until it is provided.
 
@@ -40,7 +36,7 @@ Use these constants exactly unless the user explicitly gives different values:
 |---|---|
 | Publisher prefix | `catmgr` |
 | Authoring mode | `cli-copilot` |
-| Target display name | Provided by caller, usually `NEW <source displayName>` |
+| Target display name | Provided by caller, usually `<source displayName> (migrated)` |
 | Target project directory | Provided by caller |
 | Target environment ID | Provided by caller |
 

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -34,7 +34,8 @@ pac
 
 Read the PAC CLI version from the command output. Continue only when the installed PAC CLI version is greater than or equal to `2.9.1`.
 
-If `pac` is unavailable, the version cannot be determined, or the version is less than `2.9.1`, stop the migration and tell the user to reach out to Adi or Giorgio for the required PAC CLI version.
+If `pac` is unavailable, the version cannot be determined, or the version is less than `2.9.1`, stop the migration and tell the user to install the required PAC CLI version from https://learn.microsoft.com/en-us/power-platform/developer/cli/introduction#install-microsoft-power-platform-cli.
+Don't install PAC CLI yourself, except if the user explicitly requests it. If you do install it because the user explicitly asked you, the only installation allowed is the official `dotnet tool install --global Microsoft.PowerApps.CLI.Tool`. Instead, if the user is installing it themselves, you may also use different methods such as the windows-specific MSI or other platform-specific methods.
 
 ### 2. Confirm the agent is available locally
 
@@ -52,9 +53,9 @@ If the agent is not present locally, delegate the clone to the **Copilot Studio 
 
 With the source agent available locally, read the selected source agent's display name from `agent.mcs.yml` under `displayName`, and read the target environment ID from the selected source agent's `.mcs\conn.json` under `EnvironmentId` (migrating in a different environment is not yet supported).
 
-You'd need to initialize the new/migrated agent, and for its display name you should choose exactly `NEW <source displayName>`
+You'd need to initialize the new/migrated agent, and for its display name you should choose exactly `<source displayName> (migrated)`. If the display name is exceeding 30 characters, propose to the user some shorter alternatives that still clearly indicate the agent is migrated. Ask the user to approve one of the proposed display names or provide a different one.
 
-Use a new target project directory in the workspace named exactly like the migrated agent display name (`NEW <source displayName>`) unless the user explicitly supplied a different directory.
+Use a new target project directory in the workspace named exactly like the migrated agent display name (`<source displayName> (migrated)`) unless the user explicitly supplied a different directory.
 
 Delegate initialization to the **Copilot Studio Init** sub-agent (you can use a good, mid-tier AI model). Tell it the exact migrated agent display name, target project directory, and environment ID. Don't be too long in its task. The init sub-agent requires shorter task descriptions (as opposed to the architect sub-agent for example).
 
@@ -136,7 +137,7 @@ The architect sub-agent must receive:
 
 1. The selected source agent path.
 2. The newly initialized target agent project directory.
-3. The migrated target display name (`NEW <source displayName>`).
+3. The migrated target display name (usually `<source displayName> (migrated)`).
 4. The target environment ID.
 5. The complete Copilot Studio Describer report and the approved migration plan (including the agreed handling for every gap and every tool/action decision).
 6. The tool/action migration result, including migrated tools, intentionally excluded actions, unsupported skipped actions, and invalid selected actions.
@@ -148,7 +149,7 @@ After the architect completes, confirm that the target project still contains `s
 
 ### 8. Push the migrated agent to the target environment
 
-After the architect completes, delegate the push to the **Copilot Studio Manage** sub-agent (you can use a good, mid-tier AI model). Provide it with the target project directory and target environment ID. Confirm that the push was successful before completing the migration workflow.
+After the architect completes, delegate the push to the **Copilot Studio Manage** sub-agent (you can use a good, mid-tier AI model). Provide it with the target project directory and target environment ID. Confirm that the push was successful before completing the migration workflow. Publishing is not necessary.
 
 
 ---


### PR DESCRIPTION
## Summary
- Update migration guidance to use `<source displayName> (migrated)` instead of `NEW <source displayName>`.
- Clarify PAC CLI installation guidance and migrated display-name length handling.
- Note that publishing is not necessary after pushing the migrated agent.

## Validation
- Documentation-only change; no tests run.