### PR TITLE
Support flow action migration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "mcs-assistant",
       "description": "Microsoft Copilot Studio new orchestration YAML authoring toolkit. Create, edit, validate, and test Copilot Studio agents using YAML files.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcs-assistant",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Microsoft Copilot Studio new orchestration YAML authoring toolkit. Create, edit, validate, and test Copilot Studio agents using YAML files.",
   "author": {
     "name": "Microsoft Copilot Studio CAT Team"

--- a/agents/copilot-studio-describer.md
+++ b/agents/copilot-studio-describer.md
@@ -38,6 +38,7 @@ Read broadly before reporting. Include all files that can explain behavior:
 - `settings.mcs.yml` (especially for the agent configuration, active capabilities, authentication, recognizer, model, and toggles)
 - Topics under `topics/` (somewhat useful to understand if there are some "conversational workflows")
 - Actions and connector definitions under `actions/` (and if those actions are triggered automatically, why, and when)
+- For `InvokeFlowTaskAction` actions, use the flow name and metadata first. When they do not sufficiently explain the behavior, match `action.flowId` to the ID suffix of its folder under `workflows/` and inspect `workflow.json` to understand the trigger inputs, processing steps, external dependencies, and response outputs.
 - Knowledge source files under `knowledge/` or equivalent folders. You do not need to read the actual source documents, but you must identify the configured knowledge source names/descriptions and URLs, to try to infer what they contain.
 - Variables, entities, dialogs, child agents, connected agents, and other agent-local YAML files
 - Other potential useful files

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -93,7 +93,7 @@ Before building the user-approved migration plan, inspect the legacy action file
 node scripts\convert-actions-to-tools.js <legacy-actions-folder> --list
 ```
 
-Use the inventory and the describer report together to identify every legacy action's source file name, whole `mcs.metadata` object, `modelDisplayName`, `modelDescription`, `action.operationId`, support status, and likely relevance to the modern agent. The source file name is the stable selector to use later with `--include` or `--exclude`.
+Use the inventory and the describer report together to identify every legacy action's source file name, whole `mcs.metadata` object, `modelDisplayName`, `modelDescription`, `action.operationId` or `action.flowId` as applicable, support status, and likely relevance to the modern agent. For workflow actions, the converter resolves the sibling `workflows` folder by matching the `flowId` to the ID suffix in the workflow folder name and inventories the inputs and outputs extracted from `workflow.json`. The source file name is the stable selector to use later with `--include` or `--exclude`.
 
 ### 5b. Review and approve the migration plan (mandatory gate)
 
@@ -106,8 +106,8 @@ Before any tool migration or YAML implementation, the user must approve a **migr
      - `migrate`: convert this action into a modern tool.
      - `skip`: intentionally exclude this action/capability from the modern agent.
      - `manual`: do not auto-convert; the architect should implement the behavior another way or list it as a gap.
-     - `unsupported`: the action cannot be auto-converted; pass it to the architect for manual refactor or gap handling if the capability remains in scope.
-   - **Migration plan** — for each open gap the describer surfaced (e.g., duplicate regional knowledge as topics vs sub-agents, non-migratable ServiceNow flows, language handling, country allow-lists, cleanup), propose how to handle it in the migration with a recommended approach, not just an open question. Make these proposals concrete so the user can react to a plan rather than start from a blank page.
+     - `unsupported`: the action cannot be auto-converted; pass it to the architect for manual refactor or gap handling if the capability remains in scope. A workflow lookup failure is `unsupported`, because the architect may still be able to identify the renamed workflow folder and author the tool from `workflow.json`.
+   - **Migration plan** — for each open gap the describer surfaced (e.g., duplicate regional knowledge as topics vs sub-agents, non-migratable flows, language handling, country allow-lists, cleanup), propose how to handle it in the migration with a recommended approach, not just an open question. Make these proposals concrete so the user can react to a plan rather than start from a blank page.
    - Offer the full describer report on request.
 2. **Present the whole plan and ask for approval** using the `ask_user` tool. Offer only two explicit choices — **Approve** (proceed to migration) and **Stop** — plus the free-text "Other" option that `ask_user` provides. Do not add a separate "request changes" choice: the free-text "Other" already lets the user request changes or comment on any part of the plan (description corrections, a different gap resolution, added guidance). Make the prompt clear that typing in "Other" is how to request changes.
 3. **Iterate on comments.** If the user requests changes via the free-text answer, apply their feedback: for description corrections, send the feedback to the existing describer sub-agent (via `write_agent`) so it refines the same report with full context; for plan/gap-handling changes, update the proposals directly. Then re-present the **entire** plan in full again — the complete "what the new agent is for" paragraph, the full capabilities table with every row rendered, and the full migration plan — with the requested changes already applied. Do NOT show a diff, delta, or shorthand such as "same as above, minus the X row"; always render the whole updated plan from top to bottom so the user reviews the complete current state each round. Then ask for approval once more. Repeat until the user approves or stops.
@@ -131,7 +131,9 @@ Do not use `--clean` with `--include` or `--exclude`; partial migration must not
 
 Step 4: Capture the converted-tool report, including converted tools, unsupported or invalid selected actions, and intentionally excluded actions. Update the sibling `MIGRATION-PLAN-<random>.md` file with the tool migration result before proceeding.
 
-The script will convert supported connector and MCP actions, but will automatically skip workflows, AI Prompts, or other unsupported actions. If selected actions are unsupported, do not treat that as a failure by itself. Capture the skipped unsupported action list and pass it to the Architect agent so that the behavior can be manually refactored into instructions, skills, knowledge, or explicit open gaps.
+The script will convert supported connector, MCP, and workflow actions, but will automatically skip AI Prompts or other unsupported actions. Workflow conversion reads the matching classic `workflow.json`, emits only a `WorkflowTool` YAML under the target `capabilities\tools` folder, and does not copy `workflow.json` or any other classic workflow files into the modern agent. If a workflow folder cannot be matched automatically by its ID suffix, capture it as unsupported and tell the Architect agent to inspect the source `workflows` folder and attempt a semantic match before treating it as an open gap. If selected actions are unsupported, do not treat that as a failure by itself. Capture the skipped unsupported action list and pass it to the Architect agent so that the behavior can be manually refactored into instructions, skills, knowledge, or explicit open gaps.
+
+The converter initially uses the classic workflow package's default description, falling back to an action description only when the package has none. Treat that generated workflow-tool description as a placeholder: explicitly require the Architect agent to review every converted `WorkflowTool` and replace its `mcs.metadata.description` with a clear, purpose-specific tool description based on the approved capability plan and source workflow definition.
 
 Step 5: If no converted tools are connector-backed, skip this step. A connector-backed tool is any converted tool with: `kind: ConnectorTool` OR `connectorId` OR `connectionReference`
 
@@ -197,6 +199,7 @@ The architect sub-agent must receive:
 5. The complete Copilot Studio Describer report and the approved migration plan (including the agreed handling for every gap and every tool/action decision).
 6. The tool/action migration result, including migrated tools, intentionally excluded actions, unsupported skipped actions, and invalid selected actions.
 7. The user's decisions on the open gaps, as captured in the approved plan (step 5b).
+8. An explicit instruction to review every converted `WorkflowTool` description and improve generic classic-flow descriptions so they accurately explain when and why the modern agent should use the tool.
 
 Tell the architect explicitly that the final migration artifact is the YAML written under the target project directory. If the describer report identifies gaps or uncertainties in understanding the original agent, discuss implementation strategies with the user before proceeding, and highlight those to the architect so it can make reasonable assumptions where needed to complete the YAML implementation, while listing any unresolved gaps in its final response.
 

--- a/scripts/convert-actions-to-tools.js
+++ b/scripts/convert-actions-to-tools.js
@@ -19,6 +19,8 @@ function usage() {
       "  node convert-actions-to-tools.js <legacy-actions-folder> <new-tools-folder> [--all] [--include <action-file...>] [--exclude <action-file...>] [--report <path>] [--clean]",
       "  node convert-actions-to-tools.js <legacy-actions-folder> --list [--include <action-file...>] [--exclude <action-file...>] [--report <path>]",
       "",
+      "Flow actions are resolved from the workflows folder next to the legacy actions folder.",
+      "",
       "Examples:",
       "  node convert-actions-to-tools.js \"C:\\Users\\gughini\\CopilotStudio\\SST\\actions\" \"C:\\Users\\gughini\\CopilotStudio\\dragent\\Giorgio2Clone\\capabilities\\tools\" --clean",
       "  node convert-actions-to-tools.js \"C:\\Users\\gughini\\CopilotStudio\\SST\\actions\" \"C:\\Users\\gughini\\CopilotStudio\\dragent\\Giorgio2Clone\\capabilities\\tools\" --include \"SQLServer-ExecuteaSQLqueryV2.mcs.yml\" \"Dataverse-Listrows.mcs.yml\" --report tools-report.json",
@@ -277,6 +279,160 @@ function baseMetadata(document, fallbackName) {
   };
 }
 
+function unsupportedWorkflow(reason) {
+  return { skipped: reason, supportStatus: "unsupported" };
+}
+
+function resolveWorkflowPackage(sourceFolder, flowId) {
+  const workflowsFolder = path.join(path.dirname(sourceFolder), "workflows");
+  if (!fs.existsSync(workflowsFolder) || !fs.statSync(workflowsFolder).isDirectory()) {
+    return unsupportedWorkflow(`Could not find sibling workflows folder for flow '${flowId}'`);
+  }
+
+  let workflowFolders;
+  try {
+    workflowFolders = fs
+      .readdirSync(workflowsFolder, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name.toLowerCase().endsWith(`-${flowId.toLowerCase()}`));
+  } catch (error) {
+    return unsupportedWorkflow(`Could not inspect workflows folder for flow '${flowId}': ${error.message}`);
+  }
+
+  if (workflowFolders.length === 0) {
+    return unsupportedWorkflow(`Could not match flow '${flowId}' to a workflow folder by ID suffix`);
+  }
+  if (workflowFolders.length > 1) {
+    return unsupportedWorkflow(`Flow '${flowId}' matched multiple workflow folders by ID suffix`);
+  }
+
+  const workflowFolder = path.join(workflowsFolder, workflowFolders[0].name);
+  const workflowJsonPath = path.join(workflowFolder, "workflow.json");
+  if (!fs.existsSync(workflowJsonPath) || !fs.statSync(workflowJsonPath).isFile()) {
+    return unsupportedWorkflow(`Matched workflow folder for flow '${flowId}' has no workflow.json`);
+  }
+
+  let workflow;
+  try {
+    const workflowText = fs.readFileSync(workflowJsonPath, "utf8").replace(/^\uFEFF/, "");
+    workflow = JSON.parse(workflowText);
+  } catch (error) {
+    return unsupportedWorkflow(`Could not parse workflow.json for flow '${flowId}': ${error.message}`);
+  }
+
+  const metadataPath = ["metadata.yml", "metadata.yaml"]
+    .map((fileName) => path.join(workflowFolder, fileName))
+    .find((candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile());
+  let metadata = {};
+  if (metadataPath) {
+    try {
+      metadata = parseYaml(fs.readFileSync(metadataPath, "utf8"));
+    } catch (error) {
+      return unsupportedWorkflow(`Could not parse workflow metadata for flow '${flowId}': ${error.message}`);
+    }
+  }
+
+  return {
+    workflow,
+    metadata,
+    workflowFolder,
+    workflowJsonPath,
+  };
+}
+
+function workflowInputDefinitions(workflow) {
+  const schema = workflow?.properties?.definition?.triggers?.manual?.inputs?.schema;
+  const properties = schema?.properties;
+  if (!properties || typeof properties !== "object" || Array.isArray(properties)) {
+    return undefined;
+  }
+
+  return Object.entries(properties).map(([propertyName, property]) => {
+    const displayName = property?.title || propertyName;
+    return {
+      name: displayName,
+      displayName,
+      description: property?.description,
+    };
+  });
+}
+
+function workflowOutputDefinitions(workflow) {
+  const outputs = new Map();
+
+  function visit(node) {
+    if (!node || typeof node !== "object") return;
+
+    if (node.type === "Response" && node.kind === "Skills") {
+      const properties = node.inputs?.schema?.properties;
+      if (properties && typeof properties === "object" && !Array.isArray(properties)) {
+        for (const propertyName of Object.keys(properties)) {
+          outputs.set(propertyName, { name: propertyName });
+        }
+      }
+    }
+
+    for (const value of Object.values(node)) {
+      visit(value);
+    }
+  }
+
+  visit(workflow?.properties?.definition?.actions);
+  return [...outputs.values()];
+}
+
+function convertFlowAction(document, action, sourceFolder) {
+  if (!action.flowId) {
+    return { skipped: "Flow action is missing flowId" };
+  }
+
+  const workflowPackage = resolveWorkflowPackage(sourceFolder, String(action.flowId));
+  if (workflowPackage.skipped) {
+    return workflowPackage;
+  }
+
+  const inputs = workflowInputDefinitions(workflowPackage.workflow);
+  if (!inputs) {
+    return unsupportedWorkflow(`Workflow '${action.flowId}' has no manual trigger input schema`);
+  }
+  const outputs = workflowOutputDefinitions(workflowPackage.workflow);
+  const metadata = baseMetadata(document, "Converted workflow");
+  const description = workflowPackage.metadata.description || metadata.description;
+
+  const lines = [];
+  lines.push("mcs.metadata:");
+  lines.push(`  componentName: ${quoteYaml(metadata.componentName)}`);
+  if (description) lines.push(`  description: ${quoteYaml(description)}`);
+  lines.push("kind: WorkflowTool");
+  lines.push(`workflowId: ${quoteYaml(String(action.flowId))}`);
+
+  if (outputs.length > 0) {
+    lines.push("toolOutputs:");
+    for (const output of outputs) {
+      lines.push(`  - name: ${quoteYaml(output.name)}`);
+    }
+  }
+
+  if (inputs.length > 0) {
+    lines.push("toolInputs:");
+    for (const input of inputs) {
+      lines.push(`  - name: ${quoteYaml(input.name)}`);
+      lines.push(`    displayName: ${quoteYaml(input.displayName)}`);
+      if (input.description) lines.push(`    description: ${quoteYaml(input.description)}`);
+    }
+  }
+
+  return {
+    yaml: `${lines.join("\n")}\n`,
+    workflow: {
+      workflowId: String(action.flowId),
+      workflowFolder: workflowPackage.workflowFolder,
+      workflowJsonPath: workflowPackage.workflowJsonPath,
+      inputs,
+      outputs,
+    },
+  };
+}
+
 function convertConnectorAction(document, action) {
   const connectionReference = action.connectionReference;
   const connectorId = inferConnectorId(connectionReference);
@@ -346,7 +502,7 @@ function convertMcpAction(document, action) {
   return { yaml: `${lines.join("\n")}\n` };
 }
 
-function convertTaskDialog(document) {
+function convertTaskDialog(document, sourceFolder) {
   if (document.kind !== "TaskDialog") {
     return { skipped: `Unsupported top-level kind '${document.kind || "unknown"}'` };
   }
@@ -359,7 +515,7 @@ function convertTaskDialog(document) {
     return convertMcpAction(document, action);
   }
   if (action.kind === "InvokeFlowTaskAction") {
-    return { skipped: "Flow actions are not supported" };
+    return convertFlowAction(document, action, sourceFolder);
   }
   if (action.kind === "InvokeAIBuilderModelTaskAction") {
     return { skipped: "AI prompt actions are not supported" };
@@ -374,6 +530,7 @@ function actionOperationId(action) {
 
 function supportStatus(result) {
   if (!result.skipped) return "convertible";
+  if (result.supportStatus) return result.supportStatus;
   if (result.skipped.includes("missing")) return "invalid";
   return "unsupported";
 }
@@ -408,11 +565,15 @@ function inventoryEntry(fileName, document, result) {
     modelDescription: document.modelDescription,
     kind: document.kind,
     actionKind: action.kind,
+    flowId: action.flowId,
     connectionReference: action.connectionReference,
     connectorId: inferConnectorId(action.connectionReference),
     operationId: actionOperationId(action),
     inputs: Array.isArray(document.inputs) ? document.inputs.map(inventoryInput) : [],
     outputs: Array.isArray(document.outputs) ? document.outputs.map(inventoryOutput) : [],
+    workflowInputs: result.workflow?.inputs,
+    workflowOutputs: result.workflow?.outputs,
+    workflowFolder: result.workflow?.workflowFolder,
     supportStatus: supportStatus(result),
   };
 
@@ -427,7 +588,7 @@ function readAction(sourceFolder, fileName) {
   const sourcePath = path.join(sourceFolder, fileName);
   const text = fs.readFileSync(sourcePath, "utf8");
   const document = parseYaml(text);
-  const result = convertTaskDialog(document);
+  const result = convertTaskDialog(document, sourceFolder);
   return {
     document,
     result,
@@ -588,6 +749,7 @@ function printInventory(inventory) {
     console.log(`  modelDisplayName: ${indentInventoryValue(entry.modelDisplayName, 22)}`);
     console.log(`  modelDescription: ${indentInventoryValue(entry.modelDescription, 22)}`);
     console.log(`  action.operationId: ${indentInventoryValue(entry.operationId, 22)}`);
+    console.log(`  action.flowId: ${indentInventoryValue(entry.flowId, 17)}`);
   }
 }
 


### PR DESCRIPTION
Classic workflow actions were always treated as unsupported, leaving flow-backed capabilities for manual migration. This adds automatic conversion when the corresponding classic workflow package can be resolved by flow ID.

## What changed

- Match sibling workflow folders by the `action.flowId` suffix and parse their `workflow.json` definitions.
- Emit modern `WorkflowTool` YAML with trigger inputs and response outputs while keeping classic workflow files out of the target agent.
- Include workflow details in action inventory and retain an unsupported fallback when automatic lookup fails.
- Require the Architect to refine placeholder workflow descriptions and attempt semantic recovery of unmatched workflow folders.

## Notes

Workflow descriptions initially come from classic workflow metadata and are reviewed during Architect implementation.