### PR TITLE
Add publisher prefix, schema name, and solution selection to migrate flow

### DIFF
--- a/agents/copilot-studio-init.md
+++ b/agents/copilot-studio-init.md
@@ -23,11 +23,8 @@ You need these inputs before doing any setup:
 1. Target migrated agent display name.
 2. Target project directory.
 3. Target environment ID.
-4. Publisher prefix for the solution and components (the caller-approved customization prefix, e.g. `zava`). If the caller does not provide one, fall back to the default `catmgr`.
 
-You may also receive one optional input:
-
-5. Full agent schema name. When the caller provides it, pass it through unchanged so PAC uses it as-is. When it is omitted, do not invent one; let PAC derive the default `{publisher-prefix}_{sanitized-name}`.
+You may also receive a publisher prefix for the solution and components (the caller-approved customization prefix, e.g. `zava`). If the caller does not provide one, fall back to the default `catmgr`.
 
 The caller should provide the target display name explicitly. In migration workflows, the new target display name is usually derived from the source agent display name by appending ` (migrated)` to it. For example, if the source agent display name is `MyAgent`, the target display name should be `MyAgent (migrated)`.
 
@@ -44,7 +41,6 @@ Use these constants exactly unless the user explicitly gives different values:
 | Target display name | Provided by caller, usually `<source displayName> (migrated)` |
 | Target project directory | Provided by caller |
 | Target environment ID | Provided by caller |
-| Agent schema name | Optional; provided by caller and used as-is, otherwise derived by PAC as `{publisher-prefix}_{sanitized-name}` |
 
 ## Deterministic execution rules
 
@@ -68,7 +64,6 @@ $TARGET_DISPLAY_NAME = "<target migrated agent display name>"
 $TARGET_PROJECT_DIR = "<target project directory>"
 $ENVIRONMENT_ID = "<environment-id>"
 $PUBLISHER_PREFIX = "<caller-approved-prefix-or-catmgr>"
-$SCHEMA_NAME = "<optional-full-schema-name-or-empty>"
 
 if ([string]::IsNullOrWhiteSpace($TARGET_DISPLAY_NAME)) {
   throw "Target display name is required."
@@ -89,24 +84,10 @@ if (Test-Path $TARGET_PROJECT_DIR) {
 
 ### 2. Initialize the empty target agent project
 
-Run the base command with the caller-approved publisher prefix:
-
 ```powershell
 pac copilot init `
   --name "$TARGET_DISPLAY_NAME" `
   --publisher-prefix $PUBLISHER_PREFIX `
-  --authoring-mode cli-copilot `
-  --project-dir "$TARGET_PROJECT_DIR" `
-  --environment "$ENVIRONMENT_ID"
-```
-
-If, and only if, the caller provided a full agent schema name, append `--schema-name "$SCHEMA_NAME"` so PAC uses it as-is instead of deriving `{publisher-prefix}_{sanitized-name}`:
-
-```powershell
-pac copilot init `
-  --name "$TARGET_DISPLAY_NAME" `
-  --publisher-prefix $PUBLISHER_PREFIX `
-  --schema-name "$SCHEMA_NAME" `
   --authoring-mode cli-copilot `
   --project-dir "$TARGET_PROJECT_DIR" `
   --environment "$ENVIRONMENT_ID"
@@ -121,9 +102,7 @@ Keep the final answer short and factual. Include:
 1. The target agent display name.
 2. The target environment ID.
 3. The target project directory.
-4. The publisher prefix used (and the schema name if one was provided).
-5. The migrated agent's Bot ID (the `Agent ID:` printed by `pac copilot init`).
-6. The unique name of the unmanaged solution that `pac copilot init` created and imported (this equals the agent schema name); downstream steps use it to set the agent's final solution and to clean up this init-created solution.
-7. Confirmation that `pac copilot init` completed.
+4. The publisher prefix used.
+5. Confirmation that `pac copilot init` completed.
 
 Do not include migration design, source-agent analysis, or recommendations.

--- a/agents/copilot-studio-init.md
+++ b/agents/copilot-studio-init.md
@@ -23,6 +23,11 @@ You need these inputs before doing any setup:
 1. Target migrated agent display name.
 2. Target project directory.
 3. Target environment ID.
+4. Publisher prefix for the solution and components (the caller-approved customization prefix, e.g. `zava`). If the caller does not provide one, fall back to the default `catmgr`.
+
+You may also receive one optional input:
+
+5. Full agent schema name. When the caller provides it, pass it through unchanged so PAC uses it as-is. When it is omitted, do not invent one; let PAC derive the default `{publisher-prefix}_{sanitized-name}`.
 
 The caller should provide the target display name explicitly. In migration workflows, the new target display name is usually derived from the source agent display name by appending ` (migrated)` to it. For example, if the source agent display name is `MyAgent`, the target display name should be `MyAgent (migrated)`.
 
@@ -34,11 +39,12 @@ Use these constants exactly unless the user explicitly gives different values:
 
 | Value | Rule |
 |---|---|
-| Publisher prefix | `catmgr` |
+| Publisher prefix | Provided by caller; defaults to `catmgr` when not supplied |
 | Authoring mode | `cli-copilot` |
 | Target display name | Provided by caller, usually `<source displayName> (migrated)` |
 | Target project directory | Provided by caller |
 | Target environment ID | Provided by caller |
+| Agent schema name | Optional; provided by caller and used as-is, otherwise derived by PAC as `{publisher-prefix}_{sanitized-name}` |
 
 ## Deterministic execution rules
 
@@ -61,6 +67,8 @@ $ErrorActionPreference = "Stop"
 $TARGET_DISPLAY_NAME = "<target migrated agent display name>"
 $TARGET_PROJECT_DIR = "<target project directory>"
 $ENVIRONMENT_ID = "<environment-id>"
+$PUBLISHER_PREFIX = "<caller-approved-prefix-or-catmgr>"
+$SCHEMA_NAME = "<optional-full-schema-name-or-empty>"
 
 if ([string]::IsNullOrWhiteSpace($TARGET_DISPLAY_NAME)) {
   throw "Target display name is required."
@@ -71,6 +79,9 @@ if ([string]::IsNullOrWhiteSpace($TARGET_PROJECT_DIR)) {
 if ([string]::IsNullOrWhiteSpace($ENVIRONMENT_ID)) {
   throw "Environment ID is required."
 }
+if ([string]::IsNullOrWhiteSpace($PUBLISHER_PREFIX)) {
+  $PUBLISHER_PREFIX = "catmgr"
+}
 if (Test-Path $TARGET_PROJECT_DIR) {
   throw "Target project directory already exists: $TARGET_PROJECT_DIR"
 }
@@ -78,10 +89,24 @@ if (Test-Path $TARGET_PROJECT_DIR) {
 
 ### 2. Initialize the empty target agent project
 
+Run the base command with the caller-approved publisher prefix:
+
 ```powershell
 pac copilot init `
   --name "$TARGET_DISPLAY_NAME" `
-  --publisher-prefix catmgr `
+  --publisher-prefix $PUBLISHER_PREFIX `
+  --authoring-mode cli-copilot `
+  --project-dir "$TARGET_PROJECT_DIR" `
+  --environment "$ENVIRONMENT_ID"
+```
+
+If, and only if, the caller provided a full agent schema name, append `--schema-name "$SCHEMA_NAME"` so PAC uses it as-is instead of deriving `{publisher-prefix}_{sanitized-name}`:
+
+```powershell
+pac copilot init `
+  --name "$TARGET_DISPLAY_NAME" `
+  --publisher-prefix $PUBLISHER_PREFIX `
+  --schema-name "$SCHEMA_NAME" `
   --authoring-mode cli-copilot `
   --project-dir "$TARGET_PROJECT_DIR" `
   --environment "$ENVIRONMENT_ID"
@@ -96,6 +121,7 @@ Keep the final answer short and factual. Include:
 1. The target agent display name.
 2. The target environment ID.
 3. The target project directory.
-4. Confirmation that `pac copilot init` completed.
+4. The publisher prefix used (and the schema name if one was provided).
+5. Confirmation that `pac copilot init` completed.
 
 Do not include migration design, source-agent analysis, or recommendations.

--- a/agents/copilot-studio-init.md
+++ b/agents/copilot-studio-init.md
@@ -122,6 +122,8 @@ Keep the final answer short and factual. Include:
 2. The target environment ID.
 3. The target project directory.
 4. The publisher prefix used (and the schema name if one was provided).
-5. Confirmation that `pac copilot init` completed.
+5. The migrated agent's Bot ID (the `Agent ID:` printed by `pac copilot init`).
+6. The unique name of the unmanaged solution that `pac copilot init` created and imported (this equals the agent schema name); downstream steps use it to set the agent's final solution and to clean up this init-created solution.
+7. Confirmation that `pac copilot init` completed.
 
 Do not include migration design, source-agent analysis, or recommendations.

--- a/agents/copilot-studio-manage.md
+++ b/agents/copilot-studio-manage.md
@@ -16,7 +16,7 @@ You use the Power Platform CLI (`pac`) to synchronize agent files with Copilot S
 
 - Use `pac copilot` commands for agent ALM. Do not use `scripts/manage-agent.bundle.js` or any `scripts/src/manage-agent.js` source code.
 - Supported replaced features: clone, pull, push, publish, and list agents.
-- Adding a pushed agent to a target unmanaged solution is supported via `pac solution list` and `pac solution add-solution-component`. This is the only `pac solution` usage in scope, and only for placing an already-pushed migrated agent into a caller-chosen solution. Do not use other `pac solution` verbs (init, import, export, pack, clone, delete, upgrade, etc.).
+- Adding a pushed agent to a target unmanaged solution and setting its final solution home is supported via `pac solution list`, `pac solution add-solution-component`, and `pac solution delete` (only to remove the init-created solution after the agent has been placed in its final home). These are the only `pac solution` usages in scope. Do not use other `pac solution` verbs (init, import, export, pack, clone, upgrade, etc.) and never create new solutions.
 - Do not add PAC features that were not part of the old management flow, such as create, delete, init, pack, quarantine, status polling, translations, AI model commands, or MCP commands.
 - Standalone local-vs-remote diff and standalone YAML validation were script-only capabilities. Do not offer or run them as manage-agent features.
 - Listing environments is not part of the attached PAC copilot command set. If an environment is needed and is not already known, ask the user for the environment ID or Dataverse URL.
@@ -61,7 +61,7 @@ For existing local workspaces:
 - Pull and push require only the project directory.
 - Publish and list agents require an environment ID or Dataverse URL.
 - Publish also requires a bot ID or schema name. Prefer a schema name or bot ID already present in the project files or user-provided context. If it is not available, ask the user.
-- Adding the agent to a target solution requires an environment ID or Dataverse URL, the agent's Bot schema name (from `settings.mcs.yml`), and the chosen solution's unique name.
+- Setting the migrated agent's final solution requires the target environment ID, the agent's Bot ID (the GUID from `pac copilot init` output / `AgentId` in `.mcs\conn.json`), the init-created solution's unique name (the `schemaName` in `settings.mcs.yml`), and — when targeting an existing solution — that solution's unique name.
 
 For clone:
 
@@ -140,25 +140,27 @@ pac copilot list --environment "<environment-id-or-dataverse-url>"
 
 PAC returns a text table for copilots in the target environment. Do not claim owner-only filtering unless the PAC output itself provides that distinction.
 
-#### Add agent to a target solution (post-push)
+#### Add agent to a target solution / set its final solution (post-push)
 
-`pac copilot push` places the agent and its components in the target environment's default solution. When the caller wants the migrated agent in a specific unmanaged solution, add it after a successful push.
+`pac copilot init` creates and imports a *new* unmanaged solution named after the agent schema name, so after push the migrated agent lives in that init-created solution — not the environment's default solution. Use this operation to place the agent in its intended final home and delete the init-created solution so no stray solution remains.
 
-Requires the target environment ID, the agent's Bot schema name (the `schemaName` in `settings.mcs.yml`), and the chosen solution's unique name.
+Requires the target environment ID, the migrated agent's **Bot ID (GUID)** (printed by `pac copilot init` as `Agent ID:` and stored as `AgentId` in `.mcs\conn.json`), and the init-created solution's unique name (equal to the `schemaName` in `settings.mcs.yml`).
 
-1. List candidate solutions and present only the unmanaged ones (exclude managed solutions and the system default solution) as a numbered pick-list showing friendly name and unique name:
+- **Final home = default solution:** delete the init-created solution. Its components (the Bot and its bot components) are not deleted; they revert to the environment's default solution.
+
+```bash
+pac solution delete --solution-name "<init-solution-unique-name>" --environment "<environment-id-or-dataverse-url>"
+```
+
+- **Final home = an existing unmanaged solution:** list solutions and present only the unmanaged ones (exclude managed solutions and the system default solution) as a numbered pick-list showing friendly name and unique name; add the agent to the chosen solution; then delete the init-created solution.
 
 ```bash
 pac solution list --environment "<environment-id-or-dataverse-url>"
+pac solution add-solution-component --environment "<environment-id-or-dataverse-url>" --solutionUniqueName "<chosen-solution-unique-name>" --component "<migrated-agent-bot-id>" --componentType Bot --AddRequiredComponents
+pac solution delete --solution-name "<init-solution-unique-name>" --environment "<environment-id-or-dataverse-url>"
 ```
 
-2. Add the agent (and its dependent bot components) to the chosen solution:
-
-```bash
-pac solution add-solution-component --environment "<environment-id-or-dataverse-url>" --solutionUniqueName "<chosen-solution-unique-name>" --component "<agent-schema-name>" --componentType 10116 --AddRequiredComponents
-```
-
-`--componentType 10116` is the Dataverse component type for a Bot; `--AddRequiredComponents` brings the agent's dependent bot components into the same solution. If PAC rejects the component type for the environment, report the exact error and confirm the current Bot component-type value before retrying rather than guessing; the associated `BotComponent` type is `10117`. Only run this after a successful push, because the components must already exist in the environment.
+Pass `--componentType Bot` by **name** (PAC auto-resolves the id; a numeric id such as `10116` is rejected) and pass `--component` as the Bot **ID/GUID** (a bot schema name does not resolve). `--AddRequiredComponents` brings the agent's dependent bot components along. Only run this after a successful push, and never create new solutions here. After the operation, confirm the agent still appears in `pac copilot list`.
 
 ## Dropped script-only capabilities
 
@@ -184,7 +186,7 @@ PAC commands generally write human-readable text or tables rather than the old s
 | Destination folder is not empty | PAC clone will not overwrite existing files | Choose a new output root or folder name; do not delete user files without explicit approval. |
 | Push asks to pull first or reports conflicts | Remote and local content both changed | Run pull, resolve resulting file conflicts with the user, then push again. |
 | Publish fails | Insufficient permissions, wrong environment, or wrong bot ID/schema name | Verify permissions, environment, and bot identifier, then retry. |
-| `add-solution-component` fails | Agent not yet pushed, wrong solution unique name, target solution is managed, or wrong component type | Confirm the push succeeded, verify the solution unique name from `pac solution list` and that it is unmanaged, and confirm the Bot component-type value before retrying. |
+| `add-solution-component` fails | Agent not yet pushed, wrong solution unique name, target solution is managed, numeric component type, or bot passed by schema name | Confirm the push succeeded; verify the solution unique name from `pac solution list` and that it is unmanaged; pass `--componentType Bot` by name (not a numeric id); pass `--component` as the Bot GUID (not the schema name). |
 
 ## Final answer
 

--- a/agents/copilot-studio-manage.md
+++ b/agents/copilot-studio-manage.md
@@ -16,6 +16,7 @@ You use the Power Platform CLI (`pac`) to synchronize agent files with Copilot S
 
 - Use `pac copilot` commands for agent ALM. Do not use `scripts/manage-agent.bundle.js` or any `scripts/src/manage-agent.js` source code.
 - Supported replaced features: clone, pull, push, publish, and list agents.
+- Adding a pushed agent to a target unmanaged solution is supported via `pac solution list` and `pac solution add-solution-component`. This is the only `pac solution` usage in scope, and only for placing an already-pushed migrated agent into a caller-chosen solution. Do not use other `pac solution` verbs (init, import, export, pack, clone, delete, upgrade, etc.).
 - Do not add PAC features that were not part of the old management flow, such as create, delete, init, pack, quarantine, status polling, translations, AI model commands, or MCP commands.
 - Standalone local-vs-remote diff and standalone YAML validation were script-only capabilities. Do not offer or run them as manage-agent features.
 - Listing environments is not part of the attached PAC copilot command set. If an environment is needed and is not already known, ask the user for the environment ID or Dataverse URL.
@@ -60,6 +61,7 @@ For existing local workspaces:
 - Pull and push require only the project directory.
 - Publish and list agents require an environment ID or Dataverse URL.
 - Publish also requires a bot ID or schema name. Prefer a schema name or bot ID already present in the project files or user-provided context. If it is not available, ask the user.
+- Adding the agent to a target solution requires an environment ID or Dataverse URL, the agent's Bot schema name (from `settings.mcs.yml`), and the chosen solution's unique name.
 
 For clone:
 
@@ -138,6 +140,26 @@ pac copilot list --environment "<environment-id-or-dataverse-url>"
 
 PAC returns a text table for copilots in the target environment. Do not claim owner-only filtering unless the PAC output itself provides that distinction.
 
+#### Add agent to a target solution (post-push)
+
+`pac copilot push` places the agent and its components in the target environment's default solution. When the caller wants the migrated agent in a specific unmanaged solution, add it after a successful push.
+
+Requires the target environment ID, the agent's Bot schema name (the `schemaName` in `settings.mcs.yml`), and the chosen solution's unique name.
+
+1. List candidate solutions and present only the unmanaged ones (exclude managed solutions and the system default solution) as a numbered pick-list showing friendly name and unique name:
+
+```bash
+pac solution list --environment "<environment-id-or-dataverse-url>"
+```
+
+2. Add the agent (and its dependent bot components) to the chosen solution:
+
+```bash
+pac solution add-solution-component --environment "<environment-id-or-dataverse-url>" --solutionUniqueName "<chosen-solution-unique-name>" --component "<agent-schema-name>" --componentType 10116 --AddRequiredComponents
+```
+
+`--componentType 10116` is the Dataverse component type for a Bot; `--AddRequiredComponents` brings the agent's dependent bot components into the same solution. If PAC rejects the component type for the environment, report the exact error and confirm the current Bot component-type value before retrying rather than guessing; the associated `BotComponent` type is `10117`. Only run this after a successful push, because the components must already exist in the environment.
+
 ## Dropped script-only capabilities
 
 The old Node.js management script exposed commands that are not part of this PAC replacement flow:
@@ -162,6 +184,7 @@ PAC commands generally write human-readable text or tables rather than the old s
 | Destination folder is not empty | PAC clone will not overwrite existing files | Choose a new output root or folder name; do not delete user files without explicit approval. |
 | Push asks to pull first or reports conflicts | Remote and local content both changed | Run pull, resolve resulting file conflicts with the user, then push again. |
 | Publish fails | Insufficient permissions, wrong environment, or wrong bot ID/schema name | Verify permissions, environment, and bot identifier, then retry. |
+| `add-solution-component` fails | Agent not yet pushed, wrong solution unique name, target solution is managed, or wrong component type | Confirm the push succeeded, verify the solution unique name from `pac solution list` and that it is unmanaged, and confirm the Bot component-type value before retrying. |
 
 ## Final answer
 

--- a/agents/copilot-studio-manage.md
+++ b/agents/copilot-studio-manage.md
@@ -16,7 +16,6 @@ You use the Power Platform CLI (`pac`) to synchronize agent files with Copilot S
 
 - Use `pac copilot` commands for agent ALM. Do not use `scripts/manage-agent.bundle.js` or any `scripts/src/manage-agent.js` source code.
 - Supported replaced features: clone, pull, push, publish, and list agents.
-- Adding a pushed agent to a target unmanaged solution and setting its final solution home is supported via `pac solution list`, `pac solution add-solution-component`, and `pac solution delete` (only to remove the init-created solution after the agent has been placed in its final home). These are the only `pac solution` usages in scope. Do not use other `pac solution` verbs (init, import, export, pack, clone, upgrade, etc.) and never create new solutions.
 - Do not add PAC features that were not part of the old management flow, such as create, delete, init, pack, quarantine, status polling, translations, AI model commands, or MCP commands.
 - Standalone local-vs-remote diff and standalone YAML validation were script-only capabilities. Do not offer or run them as manage-agent features.
 - Listing environments is not part of the attached PAC copilot command set. If an environment is needed and is not already known, ask the user for the environment ID or Dataverse URL.
@@ -61,7 +60,6 @@ For existing local workspaces:
 - Pull and push require only the project directory.
 - Publish and list agents require an environment ID or Dataverse URL.
 - Publish also requires a bot ID or schema name. Prefer a schema name or bot ID already present in the project files or user-provided context. If it is not available, ask the user.
-- Setting the migrated agent's final solution requires the target environment ID, the agent's Bot ID (the GUID from `pac copilot init` output / `AgentId` in `.mcs\conn.json`), the init-created solution's unique name (the `schemaName` in `settings.mcs.yml`), and — when targeting an existing solution — that solution's unique name.
 
 For clone:
 
@@ -140,28 +138,6 @@ pac copilot list --environment "<environment-id-or-dataverse-url>"
 
 PAC returns a text table for copilots in the target environment. Do not claim owner-only filtering unless the PAC output itself provides that distinction.
 
-#### Add agent to a target solution / set its final solution (post-push)
-
-`pac copilot init` creates and imports a *new* unmanaged solution named after the agent schema name, so after push the migrated agent lives in that init-created solution — not the environment's default solution. Use this operation to place the agent in its intended final home and delete the init-created solution so no stray solution remains.
-
-Requires the target environment ID, the migrated agent's **Bot ID (GUID)** (printed by `pac copilot init` as `Agent ID:` and stored as `AgentId` in `.mcs\conn.json`), and the init-created solution's unique name (equal to the `schemaName` in `settings.mcs.yml`).
-
-- **Final home = default solution:** delete the init-created solution. Its components (the Bot and its bot components) are not deleted; they revert to the environment's default solution.
-
-```bash
-pac solution delete --solution-name "<init-solution-unique-name>" --environment "<environment-id-or-dataverse-url>"
-```
-
-- **Final home = an existing unmanaged solution:** list solutions and present only the unmanaged ones (exclude managed solutions, the system default solutions — both `Default Solution` and `Common Data Services Default Solution` — and the init-created solution itself) as a numbered pick-list showing friendly name and unique name; add the agent to the chosen solution; then delete the init-created solution.
-
-```bash
-pac solution list --environment "<environment-id-or-dataverse-url>"
-pac solution add-solution-component --environment "<environment-id-or-dataverse-url>" --solutionUniqueName "<chosen-solution-unique-name>" --component "<migrated-agent-bot-id>" --componentType Bot --AddRequiredComponents
-pac solution delete --solution-name "<init-solution-unique-name>" --environment "<environment-id-or-dataverse-url>"
-```
-
-Pass `--componentType Bot` by **name** (PAC auto-resolves the id; a numeric id such as `10116` is rejected) and pass `--component` as the Bot **ID/GUID** (a bot schema name does not resolve). `--AddRequiredComponents` brings the agent's dependent bot components along. Only run this after a successful push, and never create new solutions here. After the operation, confirm the agent still appears in `pac copilot list`.
-
 ## Dropped script-only capabilities
 
 The old Node.js management script exposed commands that are not part of this PAC replacement flow:
@@ -186,7 +162,6 @@ PAC commands generally write human-readable text or tables rather than the old s
 | Destination folder is not empty | PAC clone will not overwrite existing files | Choose a new output root or folder name; do not delete user files without explicit approval. |
 | Push asks to pull first or reports conflicts | Remote and local content both changed | Run pull, resolve resulting file conflicts with the user, then push again. |
 | Publish fails | Insufficient permissions, wrong environment, or wrong bot ID/schema name | Verify permissions, environment, and bot identifier, then retry. |
-| `add-solution-component` fails | Agent not yet pushed, wrong solution unique name, target solution is managed, numeric component type, or bot passed by schema name | Confirm the push succeeded; verify the solution unique name from `pac solution list` and that it is unmanaged; pass `--componentType Bot` by name (not a numeric id); pass `--component` as the Bot GUID (not the schema name). |
 
 ## Final answer
 

--- a/agents/copilot-studio-manage.md
+++ b/agents/copilot-studio-manage.md
@@ -152,7 +152,7 @@ Requires the target environment ID, the migrated agent's **Bot ID (GUID)** (prin
 pac solution delete --solution-name "<init-solution-unique-name>" --environment "<environment-id-or-dataverse-url>"
 ```
 
-- **Final home = an existing unmanaged solution:** list solutions and present only the unmanaged ones (exclude managed solutions and the system default solution) as a numbered pick-list showing friendly name and unique name; add the agent to the chosen solution; then delete the init-created solution.
+- **Final home = an existing unmanaged solution:** list solutions and present only the unmanaged ones (exclude managed solutions, the system default solutions — both `Default Solution` and `Common Data Services Default Solution` — and the init-created solution itself) as a numbered pick-list showing friendly name and unique name; add the agent to the chosen solution; then delete the init-created solution.
 
 ```bash
 pac solution list --environment "<environment-id-or-dataverse-url>"

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -73,16 +73,15 @@ You'd need to initialize the new/migrated agent, and for its display name you sh
 
 Use a new target project directory in the workspace named exactly like the migrated agent display name (`<source displayName> (migrated)`) unless the user explicitly supplied a different directory.
 
-#### 4a. Choose the publisher prefix and schema name (mandatory)
+#### 4a. Choose the publisher prefix (mandatory)
 
-Before delegating to the init sub-agent, let the user control the customization prefix and schema name that identify the migrated agent and its components, instead of silently using the plugin default (`catmgr`).
+Before delegating to the init sub-agent, let the user control the publisher customization prefix used by the migrated agent and its components instead of silently using the plugin default (`catmgr`).
 
-1. **Publisher prefix.** Use `ask_user` to ask which publisher customization prefix to use for the migrated agent and all of its components (for example, `zava`). Offer the plugin default `catmgr` as the first (recommended) choice, and let the user type their own via the free-text option. Validate the chosen prefix before continuing: it must be 2-8 characters, start with a letter, contain only lowercase letters and digits, and must not be `mscrm` or start with `crm` (these are reserved). If the value is invalid, explain why and ask again. Prefixes are lowercased by Dataverse, so normalize the user's answer to lowercase.
-2. **Schema name (optional).** Ask whether the user wants a custom full agent schema name or to accept the default derivation `{publisher-prefix}_{sanitized-name}`. Offer **Use the default derived schema name** as the first (recommended) choice. If the user provides a custom schema name, it is used as-is by PAC, so validate that it starts with the chosen `<prefix>_` and otherwise leave it untouched. If the user accepts the default, do not pass a schema name and let PAC derive it.
+Use `ask_user` to ask which publisher customization prefix to use (for example, `zava`). Offer the plugin default `catmgr` as the first (recommended) choice, and let the user type their own via the free-text option. Validate the chosen prefix before continuing: it must be 2-8 alphanumeric characters, start with a letter, and must not start with `mscrm` (case-insensitive). Preserve the user's casing. If the value is invalid, explain why and ask again.
 
-Record the approved publisher prefix and (if any) schema name so they can be passed to the init sub-agent and captured in `MIGRATION-PLAN-<random>.md`.
+Record the approved publisher prefix so it can be passed to the init sub-agent and captured in `MIGRATION-PLAN-<random>.md`.
 
-Delegate initialization to the **Copilot Studio Init** sub-agent (you can use the latest good, mid-tier AI model). Tell it the exact migrated agent display name, target project directory, environment ID, the approved publisher prefix, and the custom schema name if one was provided (otherwise tell it to use the default derivation). Don't be too long in its task. The init sub-agent requires shorter task descriptions (as opposed to the architect sub-agent for example).
+Delegate initialization to the **Copilot Studio Init** sub-agent (you can use the latest good, mid-tier AI model). Tell it the exact migrated agent display name, target project directory, environment ID, and approved publisher prefix. Don't be too long in its task. The init sub-agent requires shorter task descriptions (as opposed to the architect sub-agent for example).
 
 After the init sub-agent completes, confirm the target agent's `settings.mcs.yml` exists before continuing. This step MUST be completed before migrating tools or implementing migration steps, but can be run in parallel with the "describe old agent" step.
 
@@ -219,38 +218,6 @@ After the architect completes, confirm that the target project still contains `s
 After the architect completes, validate every authored `.mcs.yml` component file under the target project, including skills, tools, knowledge, and any other component folders: PAC derives each Dataverse `botcomponent.schemaname` from the file stem, so every bot-component file stem must start with a valid customization prefix for the target environment and must be no more than 100 characters long. Use the publisher prefix approved in step 4a. If needed, rename files to short prefixed stems such as `<approved-prefix>_filename.mcs.yml` before pushing
 
 After that validation, delegate the push to the **Copilot Studio Manage** sub-agent (you can use the latest good, mid-tier AI model). There's no need to execute `pac copilot pack`, instead, you should prefer delegating to the **Copilot Studio Manage** sub-agent for `pac copilot push` instead. Provide it with the target project directory and target environment ID. Confirm that the push was successful before completing the migration workflow. Publishing is not necessary.
-
-#### 8a. Choose the target solution (mandatory)
-
-**Important:** `pac copilot init` (step 4) always creates and imports a *new* unmanaged solution named after the agent schema name (for example, schema `cat_AskHR` produces solution `cat_AskHR`). The migrated agent and its components live in that init-created solution after push — **not** in the environment's default solution. This step lets the user decide the agent's final home and cleans up that auto-created solution so no stray solution is left behind. Do **not** create any additional solutions in this workflow.
-
-Capture the migrated agent's Bot ID (a GUID) and the init-created solution unique name (the agent schema name) before starting: the Bot ID is printed by `pac copilot init` as `Agent ID:` and is also stored as `AgentId` in the target project's `.mcs\conn.json`; the init solution unique name equals the `schemaName` in the target `settings.mcs.yml`.
-
-1. **Offer the choice.** Use `ask_user` to ask where the migrated agent should live. Offer two choices plus the free-text option:
-   - **Save it in the default solution** (recommended) — the agent stays in the environment's default solution; the user can add it to a solution later.
-   - **Add it to an existing unmanaged solution** — pick from solutions already in the environment.
-   Do not offer to create a new solution.
-2. **Place the agent, then delete the init solution.** Delegate the `pac solution` operations to the **Copilot Studio Manage** sub-agent.
-   - **If the user chose the default solution:** simply delete the init-created solution. Its components (the Bot and its bot components) are not deleted; they revert to the environment's default solution.
-
-     ```powershell
-     pac solution delete --solution-name <init-solution-unique-name> --environment <target-environment-id>
-     ```
-   - **If the user chose an existing unmanaged solution:** list the environment's solutions with `pac solution list --environment <target-environment-id>`, present only the **unmanaged** ones (exclude managed solutions, the system `Default` / `Common Data Services Default Solution`, and the init-created solution itself) as a numbered pick-list by friendly name showing each unique name, and let the user pick one. If no eligible unmanaged solution exists, tell the user and fall back to the default-solution behavior above. Then add the migrated agent (and its required components) to the chosen solution, and delete the init-created solution afterward:
-
-     ```powershell
-     pac solution add-solution-component `
-       --environment <target-environment-id> `
-       --solutionUniqueName <chosen-solution-unique-name> `
-       --component <migrated-agent-bot-id> `
-       --componentType Bot `
-       --AddRequiredComponents
-
-     pac solution delete --solution-name <init-solution-unique-name> --environment <target-environment-id>
-     ```
-
-   Pass `--componentType Bot` by **name** (PAC auto-resolves the component-type id; do not pass a numeric id, which PAC rejects) and pass `--component` as the Bot **ID/GUID** (the bot schema name does not resolve here). `--AddRequiredComponents` brings the agent's dependent bot components into the chosen solution.
-3. **Confirm and record.** Confirm the commands succeeded (and that the migrated agent still appears in `pac copilot list`), then record the chosen destination — default solution or the chosen solution unique name — plus the fact that the init-created solution was deleted, in `MIGRATION-PLAN-<random>.md`.
 
 ## Output Guidance
 

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -222,23 +222,35 @@ After that validation, delegate the push to the **Copilot Studio Manage** sub-ag
 
 #### 8a. Choose the target solution (mandatory)
 
-`pac copilot push` places the migrated agent and its components in the target environment's **default** solution. After a successful push, let the user decide whether to keep that default placement or add the migrated agent to a specific unmanaged solution, so it can be moved through ALM like any other customization.
+**Important:** `pac copilot init` (step 4) always creates and imports a *new* unmanaged solution named after the agent schema name (for example, schema `cat_AskHR` produces solution `cat_AskHR`). The migrated agent and its components live in that init-created solution after push — **not** in the environment's default solution. This step lets the user decide the agent's final home and cleans up that auto-created solution so no stray solution is left behind. Do **not** create any additional solutions in this workflow.
 
-1. **Offer the choice.** Use `ask_user` to ask where the migrated agent should live. Offer **Keep it in the default solution** as the first (recommended) choice and **Add it to an existing unmanaged solution** as the second. If the user keeps the default solution, record that decision in `MIGRATION-PLAN-<random>.md` and skip the rest of this step. Do not create new solutions in this workflow.
-2. **List candidate solutions.** If the user wants to pick a solution, list the environment's solutions with `pac solution list --environment <target-environment-id>` and present only the **unmanaged** ones (exclude managed solutions and the system `Default`/`Common Data Services Default Solution`) as a numbered pick-list by friendly name, showing each solution's unique name. If no eligible unmanaged solution exists, tell the user and fall back to keeping the default solution.
-3. **Add the agent to the chosen solution.** Delegate to the **Copilot Studio Manage** sub-agent to add the migrated agent (and its required components) to the selected solution using its Bot schema name (the `schemaName` in the target `settings.mcs.yml`):
+Capture the migrated agent's Bot ID (a GUID) and the init-created solution unique name (the agent schema name) before starting: the Bot ID is printed by `pac copilot init` as `Agent ID:` and is also stored as `AgentId` in the target project's `.mcs\conn.json`; the init solution unique name equals the `schemaName` in the target `settings.mcs.yml`.
 
-```powershell
-pac solution add-solution-component `
-  --environment <target-environment-id> `
-  --solutionUniqueName <chosen-solution-unique-name> `
-  --component <migrated-agent-schema-name> `
-  --componentType 10116 `
-  --AddRequiredComponents
-```
+1. **Offer the choice.** Use `ask_user` to ask where the migrated agent should live. Offer two choices plus the free-text option:
+   - **Save it in the default solution** (recommended) — the agent stays in the environment's default solution; the user can add it to a solution later.
+   - **Add it to an existing unmanaged solution** — pick from solutions already in the environment.
+   Do not offer to create a new solution.
+2. **Place the agent, then delete the init solution.** Delegate the `pac solution` operations to the **Copilot Studio Manage** sub-agent.
+   - **If the user chose the default solution:** simply delete the init-created solution. Its components (the Bot and its bot components) are not deleted; they revert to the environment's default solution.
 
-`--componentType 10116` is the Dataverse component type for a Bot; `--AddRequiredComponents` pulls the agent's dependent bot components into the same solution so you do not have to add each one individually. If PAC rejects the component type for this environment, do not guess repeatedly: report the exact error and confirm the current Bot component-type value before retrying, and treat the associated `BotComponent` type (`10117`) as the fallback for individually adding child components.
-4. **Confirm and record.** Confirm the command succeeded, then record the chosen solution unique name (or the default-solution decision) in `MIGRATION-PLAN-<random>.md`.
+     ```powershell
+     pac solution delete --solution-name <init-solution-unique-name> --environment <target-environment-id>
+     ```
+   - **If the user chose an existing unmanaged solution:** list the environment's solutions with `pac solution list --environment <target-environment-id>`, present only the **unmanaged** ones (exclude managed solutions and the system `Default` / `Common Data Services Default Solution`) as a numbered pick-list by friendly name showing each unique name, and let the user pick one. If no eligible unmanaged solution exists, tell the user and fall back to the default-solution behavior above. Then add the migrated agent (and its required components) to the chosen solution, and delete the init-created solution afterward:
+
+     ```powershell
+     pac solution add-solution-component `
+       --environment <target-environment-id> `
+       --solutionUniqueName <chosen-solution-unique-name> `
+       --component <migrated-agent-bot-id> `
+       --componentType Bot `
+       --AddRequiredComponents
+
+     pac solution delete --solution-name <init-solution-unique-name> --environment <target-environment-id>
+     ```
+
+   Pass `--componentType Bot` by **name** (PAC auto-resolves the component-type id; do not pass a numeric id, which PAC rejects) and pass `--component` as the Bot **ID/GUID** (the bot schema name does not resolve here). `--AddRequiredComponents` brings the agent's dependent bot components into the chosen solution.
+3. **Confirm and record.** Confirm the commands succeeded (and that the migrated agent still appears in `pac copilot list`), then record the chosen destination — default solution or the chosen solution unique name — plus the fact that the init-created solution was deleted, in `MIGRATION-PLAN-<random>.md`.
 
 ## Output Guidance
 

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -73,7 +73,16 @@ You'd need to initialize the new/migrated agent, and for its display name you sh
 
 Use a new target project directory in the workspace named exactly like the migrated agent display name (`<source displayName> (migrated)`) unless the user explicitly supplied a different directory.
 
-Delegate initialization to the **Copilot Studio Init** sub-agent (you can use the latest good, mid-tier AI model). Tell it the exact migrated agent display name, target project directory, and environment ID. Don't be too long in its task. The init sub-agent requires shorter task descriptions (as opposed to the architect sub-agent for example).
+#### 4a. Choose the publisher prefix and schema name (mandatory)
+
+Before delegating to the init sub-agent, let the user control the customization prefix and schema name that identify the migrated agent and its components, instead of silently using the plugin default (`catmgr`).
+
+1. **Publisher prefix.** Use `ask_user` to ask which publisher customization prefix to use for the migrated agent and all of its components (for example, `zava`). Offer the plugin default `catmgr` as the first (recommended) choice, and let the user type their own via the free-text option. Validate the chosen prefix before continuing: it must be 2-8 characters, start with a letter, contain only lowercase letters and digits, and must not be `mscrm` or start with `crm` (these are reserved). If the value is invalid, explain why and ask again. Prefixes are lowercased by Dataverse, so normalize the user's answer to lowercase.
+2. **Schema name (optional).** Ask whether the user wants a custom full agent schema name or to accept the default derivation `{publisher-prefix}_{sanitized-name}`. Offer **Use the default derived schema name** as the first (recommended) choice. If the user provides a custom schema name, it is used as-is by PAC, so validate that it starts with the chosen `<prefix>_` and otherwise leave it untouched. If the user accepts the default, do not pass a schema name and let PAC derive it.
+
+Record the approved publisher prefix and (if any) schema name so they can be passed to the init sub-agent and captured in `MIGRATION-PLAN-<random>.md`.
+
+Delegate initialization to the **Copilot Studio Init** sub-agent (you can use the latest good, mid-tier AI model). Tell it the exact migrated agent display name, target project directory, environment ID, the approved publisher prefix, and the custom schema name if one was provided (otherwise tell it to use the default derivation). Don't be too long in its task. The init sub-agent requires shorter task descriptions (as opposed to the architect sub-agent for example).
 
 After the init sub-agent completes, confirm the target agent's `settings.mcs.yml` exists before continuing. This step MUST be completed before migrating tools or implementing migration steps, but can be run in parallel with the "describe old agent" step.
 
@@ -207,9 +216,29 @@ After the architect completes, confirm that the target project still contains `s
 
 ### 8. Push the migrated agent to the target environment
 
-After the architect completes, validate every authored `.mcs.yml` component file under the target project, including skills, tools, knowledge, and any other component folders: PAC derives each Dataverse `botcomponent.schemaname` from the file stem, so every bot-component file stem must start with a valid customization prefix for the target environment and must be no more than 100 characters long. If needed, rename files to short prefixed stems such as `<publisher>_filename.mcs.yml` before pushing
+After the architect completes, validate every authored `.mcs.yml` component file under the target project, including skills, tools, knowledge, and any other component folders: PAC derives each Dataverse `botcomponent.schemaname` from the file stem, so every bot-component file stem must start with a valid customization prefix for the target environment and must be no more than 100 characters long. Use the publisher prefix approved in step 4a. If needed, rename files to short prefixed stems such as `<approved-prefix>_filename.mcs.yml` before pushing
 
 After that validation, delegate the push to the **Copilot Studio Manage** sub-agent (you can use the latest good, mid-tier AI model). There's no need to execute `pac copilot pack`, instead, you should prefer delegating to the **Copilot Studio Manage** sub-agent for `pac copilot push` instead. Provide it with the target project directory and target environment ID. Confirm that the push was successful before completing the migration workflow. Publishing is not necessary.
+
+#### 8a. Choose the target solution (mandatory)
+
+`pac copilot push` places the migrated agent and its components in the target environment's **default** solution. After a successful push, let the user decide whether to keep that default placement or add the migrated agent to a specific unmanaged solution, so it can be moved through ALM like any other customization.
+
+1. **Offer the choice.** Use `ask_user` to ask where the migrated agent should live. Offer **Keep it in the default solution** as the first (recommended) choice and **Add it to an existing unmanaged solution** as the second. If the user keeps the default solution, record that decision in `MIGRATION-PLAN-<random>.md` and skip the rest of this step. Do not create new solutions in this workflow.
+2. **List candidate solutions.** If the user wants to pick a solution, list the environment's solutions with `pac solution list --environment <target-environment-id>` and present only the **unmanaged** ones (exclude managed solutions and the system `Default`/`Common Data Services Default Solution`) as a numbered pick-list by friendly name, showing each solution's unique name. If no eligible unmanaged solution exists, tell the user and fall back to keeping the default solution.
+3. **Add the agent to the chosen solution.** Delegate to the **Copilot Studio Manage** sub-agent to add the migrated agent (and its required components) to the selected solution using its Bot schema name (the `schemaName` in the target `settings.mcs.yml`):
+
+```powershell
+pac solution add-solution-component `
+  --environment <target-environment-id> `
+  --solutionUniqueName <chosen-solution-unique-name> `
+  --component <migrated-agent-schema-name> `
+  --componentType 10116 `
+  --AddRequiredComponents
+```
+
+`--componentType 10116` is the Dataverse component type for a Bot; `--AddRequiredComponents` pulls the agent's dependent bot components into the same solution so you do not have to add each one individually. If PAC rejects the component type for this environment, do not guess repeatedly: report the exact error and confirm the current Bot component-type value before retrying, and treat the associated `BotComponent` type (`10117`) as the fallback for individually adding child components.
+4. **Confirm and record.** Confirm the command succeeded, then record the chosen solution unique name (or the default-solution decision) in `MIGRATION-PLAN-<random>.md`.
 
 ## Output Guidance
 

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -236,7 +236,7 @@ Capture the migrated agent's Bot ID (a GUID) and the init-created solution uniqu
      ```powershell
      pac solution delete --solution-name <init-solution-unique-name> --environment <target-environment-id>
      ```
-   - **If the user chose an existing unmanaged solution:** list the environment's solutions with `pac solution list --environment <target-environment-id>`, present only the **unmanaged** ones (exclude managed solutions and the system `Default` / `Common Data Services Default Solution`) as a numbered pick-list by friendly name showing each unique name, and let the user pick one. If no eligible unmanaged solution exists, tell the user and fall back to the default-solution behavior above. Then add the migrated agent (and its required components) to the chosen solution, and delete the init-created solution afterward:
+   - **If the user chose an existing unmanaged solution:** list the environment's solutions with `pac solution list --environment <target-environment-id>`, present only the **unmanaged** ones (exclude managed solutions, the system `Default` / `Common Data Services Default Solution`, and the init-created solution itself) as a numbered pick-list by friendly name showing each unique name, and let the user pick one. If no eligible unmanaged solution exists, tell the user and fall back to the default-solution behavior above. Then add the migrated agent (and its required components) to the chosen solution, and delete the init-created solution afterward:
 
      ```powershell
      pac solution add-solution-component `


### PR DESCRIPTION
## What

Gives the user control over two things the `/migrate` workflow previously decided silently:

1. **Publisher prefix + schema name** for the migrated agent and its components (was hardcoded to `catmgr`).
2. **Target solution** for the pushed agent (previously always landed in the environment's *default* solution, with no alternative).

## Why

During migration, users frequently want the migrated agent to carry their own customization prefix (e.g. `zava_`) and to live in a specific unmanaged solution for downstream ALM. Neither was possible before.

## Changes

- **`commands/migrate.md`**
  - New **step 4a**: prompt for a publisher prefix (defaults to `catmgr`, validated) and an optional full schema name; both passed to the init sub-agent.
  - **Step 8** now uses the approved prefix for component file stems.
  - New **step 8a**: after a successful push, offer to keep the default solution *or* pick from the environment's existing unmanaged solutions, then add the agent via `pac solution add-solution-component`.
- **`agents/copilot-studio-init.md`**: accept a caller-provided publisher prefix (default `catmgr`) and optional `--schema-name` instead of hardcoding.
- **`agents/copilot-studio-manage.md`**: document the post-push "add agent to a target solution" operation (`pac solution list` + `add-solution-component`) as an in-scope capability, with input resolution and error-handling coverage.

## Notes

- Solution targeting uses the existing `pac copilot push` path (no switch to `pack`), keeping the Manage agent's no-`pack` boundary intact; the agent is added to the chosen solution afterward with `--AddRequiredComponents` so dependent bot components follow.
- `--componentType 10116` (Bot) is used with a documented fallback (`10117` = BotComponent) and instruction to verify rather than guess if an environment rejects it.
- Creating brand-new solutions is intentionally out of scope; users pick from existing unmanaged solutions or keep the default.