### PR TITLE
Add conversation starters authoring guidance to architect

### DIFF
--- a/agents/copilot-studio-architect.md
+++ b/agents/copilot-studio-architect.md
@@ -152,6 +152,36 @@ configuration:
 
 Keep existing model, recognizer, authentication, channels, language, template, `displayName`, and `schemaName` unless the describer report or user explicitly requires a supported change. Supported modern model series include `GPT5Chat`, `GPT55Chat`, `Sonnet46`, and `Opus47`.
 
+## Conversation Starters
+
+Author suggested prompts (surfaced to the end user in the M365 Copilot picker and the agent's chat surface) as a first-class field of `settings.mcs.yml` under `configuration.agentSettings`, alongside `instructions`:
+
+```yaml
+configuration:
+  agentSettings:
+    model:
+      series: <series>
+    instructions:
+      segments:
+        - kind: StaticSegment
+          value: |
+            <instructions>
+    conversationStarters:
+      - title: <short label shown on the suggestion chip>
+        text: <the message that is sent when the user picks it>
+      - title: <label>
+        text: <message>
+```
+
+Rules:
+
+- Author 3-6 starters. Fewer than 3 undersells the agent's capabilities; more than 6 clutters the picker.
+- Each `title` should be 1-4 words, imperative or noun-phrase (for example "Draft Minutes", "Explain refund policy"). Avoid a leading verb + preposition + object that duplicates `text`.
+- Each `text` is the literal prompt that will be sent to the agent as if the user typed it. Use natural language; include a placeholder like `<link>` or `<topic>` where the user is expected to fill in a value.
+- Derive starters from the agent's highest-value user journeys already described in `instructions` and skills. Do not invent scenarios the agent cannot handle.
+- Do not embed starter text inside the `instructions` static segment as a workaround. The dedicated field renders in the Copilot Studio UI, the M365 Copilot picker, and the agent's chat surface; embedding in instructions renders nowhere.
+- Preserve any existing `conversationStarters` block during edits unless the user explicitly asks to replace it.
+
 ## Knowledge YAML
 
 Create knowledge only when the source has a concrete searchable source or local uploaded file.


### PR DESCRIPTION
## Summary

Adds authoring guidance for `conversationStarters` to the Copilot Studio Architect agent (`agents/copilot-studio-architect.md`).

## Motivation

The modern `cliagent-1.0.0` schema accepts a `conversationStarters` block under `configuration.agentSettings` alongside `instructions`, but the architect agent's guidance does not currently instruct authors to populate it. As a result, agents generated by the architect land in Copilot Studio with an empty starter-prompt picker and the maker has to set them manually via the UI after every push.

Empirically verified against a freshly authored CLI-authoring agent using `cliagent-1.0.0` and the `Sonnet46` model series.

## What changed

- New section `## Conversation Starters` in `agents/copilot-studio-architect.md` (placed between `## Settings YAML` and `## Knowledge YAML`)
- Documents the exact YAML shape under `configuration.agentSettings.conversationStarters`, using the same `title` / `text` fields as the classic `default-2.1.0` schema
- Includes rules on count (3-6), title style (1-4 words), text style (literal prompt with placeholders), and the anti-pattern of embedding starter prose inside instructions

## Verification (round-trip test)

Confirmed against a live modern agent:

1. Authored `settings.mcs.yml` with a `conversationStarters` block containing 4 entries (`title` + `text`)
2. `pac copilot push` succeeded (`1 change(s) pushed`)
3. `pac copilot pull` re-emitted identical YAML (`Pull complete. 0 change(s) applied.`)
4. Compiled `.mcs/botdefinition.json` under `entity.configuration.agentSettings.conversationStarters` contained all 4 entries with matching title and text
5. Pushing again after the pull was a no-op (`No local changes detected`)

Exact YAML that round-trips cleanly:

```yaml
configuration:
  agentSettings:
    model:
      series: Sonnet46
    instructions:
      segments:
        - kind: StaticSegment
          value: |
            <instruction body>
    conversationStarters:
      - title: Draft a PID
        text: "Draft a PID from this meeting: <link>"
      - title: Draft Minutes
        text: Turn this transcript into Minutes in the standard template
```

## Scope

Documentation-only. No changes to plugin agents, commands, hooks, or scripts. The architect follows the guidance the next time it generates or edits a `settings.mcs.yml`.

## Testing

- Existing agent files: no schema regression (only additive guidance in the architect markdown)
- Manual verification described above
- No new dependencies

## Related work

- Plugin version at time of contribution: `mcs-assistant@copilot-studio-plugin v1.0.2`
- PAC CLI at time of contribution: `2.9.3+ga17df1d`
