### PR TITLE
Add agent icon authoring guidance to architect

### DIFF
--- a/agents/copilot-studio-architect.md
+++ b/agents/copilot-studio-architect.md
@@ -152,6 +152,30 @@ configuration:
 
 Keep existing model, recognizer, authentication, channels, language, template, `displayName`, and `schemaName` unless the describer report or user explicitly requires a supported change. Supported modern model series include `GPT5Chat`, `GPT55Chat`, `Sonnet46`, and `Opus47`.
 
+## Agent Icon
+
+Copilot Studio agents surface an icon in the M365 Copilot picker, the Copilot Studio agent list, and the agent's chat surface. The default icon is a generic placeholder — customer-facing agents should ship with a custom icon.
+
+Author the icon as a PNG file at the **project root**, filename `icon.png`:
+
+```text
+<target-agent>/
+├── settings.mcs.yml
+├── agent.sync.yaml
+├── icon.png            <-- 192x192 PNG, agent icon, applied automatically on push
+├── behaviors/
+├── capabilities/
+└── .mcs/
+```
+
+Rules:
+
+- File name must be exactly `icon.png`, at the project root. Files under `assets/` are ignored by the icon-detection convention.
+- PNG format, 192x192 recommended. Larger sizes are accepted but downscaled.
+- On `pac copilot push`, the file is encoded as `iconBase64` in the compiled bot definition and applied to the agent identity server-side.
+- On `pac copilot pull`, the server serialises the current icon back to `icon.png` at the project root; do not check that file into source control if it is expected to change through the UI.
+- Do not reference the icon in `settings.mcs.yml` — as of the current schema there is no YAML property for it; the on-disk convention is the entire interface.
+
 ## Knowledge YAML
 
 Create knowledge only when the source has a concrete searchable source or local uploaded file.


### PR DESCRIPTION
## Summary

Adds authoring guidance for the agent icon to the Copilot Studio Architect agent (`agents/copilot-studio-architect.md`).

## Motivation

The modern CLI-authoring template accepts an agent icon via a top-level `icon.png` file at the project root — `pac copilot push` encodes it as `iconBase64` in the compiled bot definition and applies it to the agent identity server-side. The current architect guidance does not mention this convention, so architect-authored agents ship with the generic default icon and the maker has to upload one manually via the Copilot Studio UI after every push.

Empirically verified against a freshly authored CLI-authoring agent using the `cliagent-1.0.0` template.

## What changed

- New section `## Agent Icon` in `agents/copilot-studio-architect.md` (placed between `## Settings YAML` and `## Knowledge YAML`)
- Documents the exact convention: `icon.png` at the project root (not `assets/`, not referenced from `settings.mcs.yml`)
- Includes rules on format (192×192 PNG), the server-side encoding as `iconBase64`, and the pull/push round-trip behaviour

## Verification (round-trip test)

Confirmed against a live modern agent:

1. Uploaded a custom 192×192 PNG icon via the Copilot Studio UI
2. `pac copilot pull` re-emitted the file to the project root as `icon.png` (3.4 KB PNG)
3. Compiled `.mcs/botdefinition.json` contains `"iconBase64": "iVBORw0KGgo..."` — 5,037 chars of base64 encoding the PNG
4. `settings.mcs.yml` was not modified — the icon is not referenced by any YAML property, the file-name convention is the entire interface
5. Placing the same PNG at `assets/icon.png` (as the current architect would author) is silently ignored; the file must be at the project root for `pac copilot push` to pick it up

## Scope

Documentation-only. No changes to plugin agents, commands, hooks, or scripts. The architect follows the guidance the next time it initializes a new agent project.

## Testing

- Existing agent files: no schema regression (only additive guidance in the architect markdown)
- Manual verification described above
- No new dependencies

## Related work

- Plugin version at time of contribution: `mcs-assistant@copilot-studio-plugin v1.0.2`
- PAC CLI at time of contribution: `2.9.3+ga17df1d`
- Companion PR: #24 (conversation starters authoring guidance)
